### PR TITLE
Add basic test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,12 @@
+name: Test
+
+on: [push, pull_request]
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+    - run: python -m pip install -r requirements.txt
+    - run: python src/data.py

--- a/simtools/TheVirtualBrain-(TVB).yaml
+++ b/simtools/TheVirtualBrain-(TVB).yaml
@@ -4,3 +4,4 @@
 - biological_level: Population Model, Single-Compartment (Simple) Model #TODO
 - interface_language: Python, GUI
 - model_description_language: 
+- computing_scale: Single Machine, Cluster, Supercomputer

--- a/src/data.py
+++ b/src/data.py
@@ -79,11 +79,7 @@ def parse_file(filename):
 def parse_files(dirname=Path(__file__).parent / '..' / 'simtools'):
     simulators = {}
     for f in get_files(dirname):
-        try:
-            content = parse_file(f)
-        except Exception as ex:
-            print(f"Error: {ex}")
-            continue
+        content = parse_file(f)
         simulators[content["name"]] = content
     return simulators
 

--- a/src/data.py
+++ b/src/data.py
@@ -79,7 +79,11 @@ def parse_file(filename):
 def parse_files(dirname=Path(__file__).parent / '..' / 'simtools'):
     simulators = {}
     for f in get_files(dirname):
-        content = parse_file(f)
+        try:
+            content = parse_file(f)
+        except Exception as e:
+            raise ValueError(f"Error parsing {f}") from e
+
         simulators[content["name"]] = content
     return simulators
 


### PR DESCRIPTION
A *very* basic test: will try to parse all yaml files and will fail if any of them is not parsing correctly, is missing a required field (e.g. "operating_systems"), or uses an incorrect format (yaml list instead of comma-separated string).
Examples of failures:
- Incorrect/missing field: https://github.com/OCNS/simselect/actions/runs/4872845071
- Incorrect list format: https://github.com/OCNS/simselect/actions/runs/4872856751
- Broken yaml: https://github.com/OCNS/simselect/actions/runs/4872862374

Not great, but should at least avoid breaking things completely.

Closes #12 