### PR TITLE
More details in detail view

### DIFF
--- a/simtools/Arbor-GUI.yaml
+++ b/simtools/Arbor-GUI.yaml
@@ -6,3 +6,5 @@
 - interface_language: GUI
 - model_description_language: NMODL, NeuroML2, SWC, Neurolucida, ACC
 - summary: Arbor GUI is a comprehensive tool for building single cell models using Arbor. It strives to be self-contained, fast, and easy to use.
+- relations:
+  - name: Arbor

--- a/simtools/Arbor-Playground.yaml
+++ b/simtools/Arbor-Playground.yaml
@@ -6,3 +6,5 @@
 - interface_language: GUI, Python
 - model_description_language:
 - summary: Arbor Playground is an Emscripten + Pyodide port of Arbor and is meant to be a simple showcase of neural modelling in Arbor.
+- relations:
+  - name: Arbor

--- a/simtools/Arbor.yaml
+++ b/simtools/Arbor.yaml
@@ -10,3 +10,6 @@
     documentation: https://docs.arbor-sim.org/
     source: https://github.com/arbor-sim/arbor
     email: contact@arbor-sim.org
+- relations:
+      - name: Arbor GUI
+      - name: Arbor Playground

--- a/simtools/Arbor.yaml
+++ b/simtools/Arbor.yaml
@@ -1,8 +1,12 @@
 - name: Arbor
-- website_url: https://arbor-sim.org/
 - operating_system: Linux, MacOS, Windows
 - biological_level: Population Model, Single-Compartment (Simple) Model, Single-Compartment (Complex) Model, Multi-Compartment Model
 - computing_scale: Single Machine, Cluster, Supercomputer, GPU
 - interface_language: Python, C++
 - model_description_language: NMODL, NeuroML2, SWC, Neurolucida, ACC
 - summary: Arbor is a high-performance library for computational neuroscience simulations with multi-compartment, morphologically-detailed cells, from single cell models to very large networks. Arbor is written from the ground up with many-cpu and gpu architectures in mind, to help neuroscientists effectively use contemporary and future HPC systems to meet their simulation needs.
+- urls:
+    homepage: https://arbor-sim.org/
+    documentation: https://docs.arbor-sim.org/
+    source: https://github.com/arbor-sim/arbor
+    email: contact@arbor-sim.org

--- a/simtools/Brian.yaml
+++ b/simtools/Brian.yaml
@@ -1,8 +1,16 @@
 - name: Brian
-- website_url: https://briansimulator.org/
 - operating_system: Linux, MacOS, Windows
 - biological_level: Population Model, Single-Compartment (Simple) Model, Single-Compartment (Complex) Model, Multi-Compartment Model
 - computing_scale: Single Machine, Cluster
 - interface_language: Python
 - model_description_language: #TODO
-- summary: Brian is a clock driven simulator for spiking neural networks. The simulator is written almost entirely in Python. The idea is that it can be used at various levels of abstraction without the steep learning curve of software like Neuron, where you have to learn their own programming language to extend their models. 
+- summary: Brian is a clock driven simulator for spiking neural networks. The simulator is written almost entirely in Python. The idea is that it can be used at various levels of abstraction without the steep learning curve of software like Neuron, where you have to learn their own programming language to extend their models.
+- urls:
+    homepage: https://briansimulator.org/
+    documentation: https://brian2.readthedocs.io/
+    source: https://github.com/brian-team/brian2
+    issue tracker: https://github.com/brian-team/brian2/issues
+    download: https://pypi.org/project/Brian2/
+    forum: https://brian.discourse.group
+    chat: https://gitter.im/brian-team/brian2
+

--- a/simtools/README.md
+++ b/simtools/README.md
@@ -1,0 +1,39 @@
+This folder contains one file for each simulator. The file `simtools.yaml` is
+ignored. (It is a file with information that was gathered previously and is now
+replaced by the  individual files. As soon as all the information is
+transferred, the file will be deleted.)
+
+The file for each simulator should have a name that is the same as the name of
+the simulator, avoiding spaces. Each file is a `YAML` file with the following
+structure (additional fields not mentioned below will be ignored; the values
+shown below are obviously example values):
+
+```yaml
+- name: Simulator Name
+- operating_system: Linux, MacOS
+- biological_level: Population Model, Single-Compartment (Simple) Model, Single-Compartment (Complex) Model, Multi-Compartment Model
+- computing_scale: Single Machine, Cluster, Supercomputer, GPU
+- interface_language: Python
+- model_description_language: NeuroML2
+- summary: This simulator is very good.
+- urls:
+    homepage: https://example.com
+    email: contact@example.com
+- relations:
+      - name: Another simulator
+      - name: Yet another simulator
+```
+The fields `operating_system`, `biological_level`, `computing_scale`,
+`interface_language`, and `model_description_language` are comma-separated
+strings (i.e. not yaml lists).
+
+The `urls` field can contain arbitrary keys that will be displayed as button
+labels. A  number of names will be recognized and will be displayed with a
+special icon: `homepage`, `source`, `documentation`, `issue tracker`,
+`download`, `release notes`, `email`, `chat`, and `forum`. The `email` field
+should refer to  an email address (which will be converted into a `mailto:`
+link), all other  fields should give a full URL.
+
+Relations are a list of other simulators that are related to the current
+simulator. The mentioned `name` needs to match the `name` of another simulator
+in the directory.

--- a/src/data.py
+++ b/src/data.py
@@ -73,6 +73,14 @@ def parse_file(filename):
     else:
         description_language_key = "model_description_language"
     content_dict["model_description_language"] = string_to_list(content_dict[description_language_key])
+
+    if 'website_url' in content_dict:
+        if 'urls' in content_dict:
+            raise ValueError(f"Both 'website_url' and 'urls' are defined in,"
+                             f" {filename}. Use homepage in urls instead.")
+        content_dict['urls'] = {'homepage': content_dict['website_url']}
+        del content_dict['website_url']
+
     return content_dict
 
 

--- a/src/data.py
+++ b/src/data.py
@@ -94,6 +94,12 @@ def parse_files(dirname=Path(__file__).parent / '..' / 'simtools'):
         # Store the filename itself
         content["filename"] = f.name
         simulators[content["name"]] = content
+
+    # Verify that relations point to valid names
+    for sim in simulators.values():
+        for relation in sim.get('relations', []):
+            if relation['name'] not in simulators:
+                raise ValueError(f"Unknown simulator '{relation['name']}' in relations of '{sim['name']}'")
     return simulators
 
 

--- a/src/project_browser.py
+++ b/src/project_browser.py
@@ -162,19 +162,33 @@ class SimSelect:
 {criteria}
 """
         self.template.modal[0].clear()
+        rows = [description]
         url_buttons = []
         for url_type, url in data.get("urls", {}).items():
             icon = get_icon(url_type, url)
             url_button = pn.widgets.Button(icon=icon, name=url_type.capitalize(),
-                                           button_type="primary")
-            if url_type.lower == 'email':
+                                           button_type="default")
+            if url_type.lower() == 'email':
                 url_button.js_on_click(code=f"window.open('mailto:{url}')")
             else:
                 url_button.js_on_click(code=f"window.open('{url}')")
             url_buttons.append(url_button)
-        buttons = pn.Row(*url_buttons)
 
-        layout = pn.Column(description, buttons)
+        if url_buttons:
+            buttons = pn.Row(*url_buttons)
+            rows.append(buttons)
+
+        if data.get('relations', []):
+            rows.append("## Related simulators")
+            relation_buttons = []
+            for relation in data['relations']:
+                relation_button = pn.widgets.Button(name=relation['name'],
+                                                    button_type="primary")
+                relation_button.on_click(self.simulator_details)
+                relation_buttons.append(relation_button)
+            rows.append(pn.Row(*relation_buttons))
+
+        layout = pn.Column(*rows)
         self.template.modal[0].append(layout)
         self.template.open_modal()
 

--- a/src/project_browser.py
+++ b/src/project_browser.py
@@ -45,7 +45,7 @@ def get_icon(url_type, url):
             return 'package'
         else:
             return 'download'
-    elif url_type.lower() == 'release_notes':
+    elif url_type.lower() == 'release notes':
         return 'notes'
     elif url_type.lower() == 'email':
         return 'mail'

--- a/src/project_browser.py
+++ b/src/project_browser.py
@@ -12,6 +12,50 @@ def github_url(filename):
     return f"{REPO_URL}/edit/main/{DATA_FOLDER}/{filename}"
 
 
+def get_icon(url_type, url):
+    """
+    Returns an appropriate icon from https://tabler-icons.io based on the url
+    type and url.
+
+    Args:
+        url_type: str
+        url: str
+
+    Returns:
+        icon: str or None
+            The name of the icon to use or None
+    """
+    if url_type.lower() == 'homepage':
+        return 'home'
+    elif url_type.lower() == 'source':
+        if 'github.com' in url.lower():
+            return 'brand-github'
+        elif 'gitlab.com' in url.lower():
+            return 'brand-gitlab'
+        elif 'bitbucket.org' in url.lower():
+            return 'brand-bitbucket'
+        else:
+            return 'code'
+    elif url_type.lower() == 'documentation':
+        return 'book'
+    elif url_type.lower() == 'issue tracker':
+        return 'bug'
+    elif url_type.lower() == 'download':
+        if 'pypi.org' in url.lower():
+            return 'package'
+        else:
+            return 'download'
+    elif url_type.lower() == 'release_notes':
+        return 'notes'
+    elif url_type.lower() == 'email':
+        return 'mail'
+    elif url_type.lower() == 'chat':
+        return 'message-circle-2'
+    elif url_type.lower() == 'forum':
+        return 'messages'
+    else:
+        return None
+
 class SimSelect:
     DATA = data.parse_files()
     VALUES = data.unique_entries(DATA)
@@ -118,9 +162,15 @@ class SimSelect:
 {criteria}
 """
         self.template.modal[0].clear()
-        website_button = pn.widgets.Button(icon="external-link", name="Website", button_type="primary")
-        website_button.js_on_click(code=f"window.open('{data['website_url']}')")
-        buttons = pn.Row(website_button)
+        url_buttons = []
+        for url_type, url in data.get("urls", {}).items():
+            icon = get_icon(url_type, url)
+            url_button = pn.widgets.Button(icon=icon, name=url_type.capitalize(),
+                                           button_type="primary")
+            url_button.js_on_click(code=f"window.open('{url}')")
+            url_buttons.append(url_button)
+        buttons = pn.Row(*url_buttons)
+
         layout = pn.Column(description, buttons)
         self.template.modal[0].append(layout)
         self.template.open_modal()

--- a/src/project_browser.py
+++ b/src/project_browser.py
@@ -9,7 +9,7 @@ DATA_FOLDER = "simtools"
 
 
 def github_url(filename):
-    return f"'{REPO_URL}/edit/main/{DATA_FOLDER}/{filename}'"
+    return f"{REPO_URL}/edit/main/{DATA_FOLDER}/{filename}"
 
 
 class SimSelect:
@@ -111,7 +111,7 @@ class SimSelect:
 
         criteria = self.formatted_criteria(data)
         description = f"""
-# {data['name']}
+# {data['name']} [\u270e]({github_url(data['filename'])} "Propose changes to this entry")
 
 {data.get('summary', '')}
 
@@ -120,9 +120,7 @@ class SimSelect:
         self.template.modal[0].clear()
         website_button = pn.widgets.Button(icon="external-link", name="Website", button_type="primary")
         website_button.js_on_click(code=f"window.open('{data['website_url']}')")
-        edit_button = pn.widgets.Button(icon="database-edit", name="Propose changes", button_type="primary")
-        edit_button.js_on_click(code=f"window.open({github_url(data['filename'])})")
-        buttons = pn.Row(website_button, edit_button)
+        buttons = pn.Row(website_button)
         layout = pn.Column(description, buttons)
         self.template.modal[0].append(layout)
         self.template.open_modal()

--- a/src/project_browser.py
+++ b/src/project_browser.py
@@ -167,7 +167,10 @@ class SimSelect:
             icon = get_icon(url_type, url)
             url_button = pn.widgets.Button(icon=icon, name=url_type.capitalize(),
                                            button_type="primary")
-            url_button.js_on_click(code=f"window.open('{url}')")
+            if url_type.lower == 'email':
+                url_button.js_on_click(code=f"window.open('mailto:{url}')")
+            else:
+                url_button.js_on_click(code=f"window.open('{url}')")
             url_buttons.append(url_button)
         buttons = pn.Row(*url_buttons)
 


### PR DESCRIPTION
This lays the foundation for #9/#10 and #7, by now supporting various types of URLs and basic relationships in the detail view. See https://github.com/OCNS/simselect/blob/more_details/simtools/README.md for the current yaml structure.

The detail view looks like this at the moment:
![image](https://github.com/OCNS/simselect/assets/1381982/6db9931f-5447-4236-be03-1ece4e96e381)
