### PR TITLE
Update NeuroML.yaml

### DIFF
--- a/simtools/NeuroML.yaml
+++ b/simtools/NeuroML.yaml
@@ -36,3 +36,4 @@
     - name: EDEN
     - name: Brian
     - name: PyNN
+    - name: Arbor


### PR DESCRIPTION
A slight update. But, this is a bit of a strange one: I think NeuroML is a format first, and (somewhat confusingly) a tool second (and isn't that simulator actually called LEMS?). Some tools feature NML as language already, which is currently not used for the relations field. If we add file formats here, it might be good to use that field too to create links.