### PR TITLE
feat: Add a help button to explain filter criteria

### DIFF
--- a/src/project_browser.py
+++ b/src/project_browser.py
@@ -1,3 +1,5 @@
+import os
+from pathlib import Path
 import random
 
 import panel as pn
@@ -227,7 +229,15 @@ class SimSelect:
             )
         )
         self.template.sidebar.append(self.search_box)
-        self.template.sidebar.append("## Filter by")
+        self.template.sidebar.append(pn.layout.Divider())
+        filter_help = pn.widgets.Button(name="Help",
+                                        icon="help-circle",
+                                        button_type="light",
+                                        button_style="outline",
+                                        icon_size="1.5em")
+        filter_help.on_click(lambda event: self.template.open_modal())
+        self.template.sidebar.append(pn.Row("## Filter by",
+                                            filter_help))
         for key in self.select_widgets:
             self.template.sidebar.append(self.select_widgets[key])
 
@@ -249,6 +259,12 @@ class SimSelect:
             self.select_widgets[key].param.watch(self.update_cards, "value")
         # Watch the search box
         self.search_box.param.watch(self.update_cards, "value_input")
+
+        # Fill the help modal
+        with open(Path(__file__).parent / ".." / "static" / "filter_criteria.md") as f:
+            filter_help_text = pn.pane.Markdown(f.read(), renderer="markdown",
+                                                extensions=["def_list"])
+        self.template.modal.append(filter_help_text)
 
 
 if __name__.startswith("bokeh"):

--- a/static/filter_criteria.md
+++ b/static/filter_criteria.md
@@ -1,0 +1,44 @@
+## Explanation of the filter criteria
+
+### Model type
+
+**Population model**
+:   Models that do not describe the activity at the level of individual cells,
+    but rather on the level of populations.
+
+    Also known as: *Population density models, Ensemble models, mean field models*
+
+**Single compartment (Simple) model**
+:   Highly simplified models of individual neurons, that do not model the
+    biological details (e.g. action potential generation). Typically, the neural
+    activity is described with a single differential equation and an explicit
+    threshold/reset mechanism.
+
+    Examples: *binary neuron model, integrate-and-fire model, Izhikevich model*
+
+**Single compartment (Complex) model**
+:   Models of individual neurons, that model biological details such as ion
+    channels and action potential generation. Neurons are modeled as "point
+    neurons", i.e. no attempt to model their spatial morphology is made.
+
+    Examples: *Hodgkin-Huxley model (point neuron), conductance-based model*
+
+**Multi-Compartment model**
+:   Models that take the spatial morphology into account, by representing each
+    neuron as multiple interconnected "compartments". This makes it possible to
+    study the spatial propagation and integration of signals along dendrites and
+    axons.
+
+### Computing power
+
+**Single Machine**
+:   A single desktop computer or laptop.
+
+**Cluster**
+:   A cluster of computers, typically connected via a high-speed network.
+
+**Supercomputer**
+:   A supercomputer, typically with a large number of CPUs and (possibly) GPUs.
+
+**GPU**
+:   A graphics card capable of performing general purpose computations.


### PR DESCRIPTION
So it turns out that this is a little bit trickier than I thought.

Newer versions of `panel` have a `description` argument which you can use for tooltips – this sounds exactly what we want and adds a nice little help icon:

![image](https://github.com/OCNS/simselect/assets/1381982/ada23c8a-9960-483a-a6bb-6c05cd607c92)

But unfortunately, it crops the content to the sidebar:
![image](https://github.com/OCNS/simselect/assets/1381982/cbcea9a7-93a3-4710-8992-49c9e1144ebb)

I tried working around this, and tried manually adding buttons to the side bar, but the layout is tricky, since it is all wrapped in an `<ul>` and basically only meant to stack things vertically. For now, I opted for using the modal again, with a manual button next to "Filter By".

![image](https://github.com/OCNS/simselect/assets/1381982/fb6380c4-7bff-428f-98a3-f6a7d13ec780)

This doesn't look great (the placement is off, etc.) but maybe as a first thing it is good enough?

![image](https://github.com/OCNS/simselect/assets/1381982/8601f287-1063-4f5f-b29c-3e73dc82d6e7)




