### PR TITLE
Improved url buttons

### DIFF
--- a/assets/buttons.css
+++ b/assets/buttons.css
@@ -1,5 +1,6 @@
-button:disabled {
+.bk-btn[disabled] {
     text-decoration: line-through;
+    opacity: var(--disabled-opacity);
 }
 
 .bk-btn-warning {

--- a/assets/buttons.css
+++ b/assets/buttons.css
@@ -4,7 +4,7 @@
 }
 
 .bk-btn.sim-detail-selected {
-    border: 3px black solid
+    border: 3px var(--neutral-foreground-rest) solid
  }
 
 .bk-btn-warning {

--- a/assets/buttons.css
+++ b/assets/buttons.css
@@ -3,6 +3,10 @@
     opacity: var(--disabled-opacity);
 }
 
+.bk-btn.sim-detail-selected {
+    border: 3px black solid
+ }
+
 .bk-btn-warning {
   background-color: #f0ad4e;
   border-color: #eea236;

--- a/assets/buttons.css
+++ b/assets/buttons.css
@@ -1,3 +1,7 @@
+button:disabled {
+    text-decoration: line-through;
+}
+
 .bk-btn-warning {
   background-color: #f0ad4e;
   border-color: #eea236;

--- a/simtools/ANNarchy.yaml
+++ b/simtools/ANNarchy.yaml
@@ -10,6 +10,8 @@
     interface in Python for the definition of the networks.
 - urls:
     documentation: https://annarchy.readthedocs.io
+    installation: https://annarchy.readthedocs.io/en/latest/Installation.html
+    examples: https://annarchy.readthedocs.io/en/latest/example/List.html
     source: https://github.com/ANNarchy/ANNarchy
     issue tracker: https://github.com/ANNarchy/ANNarchy/issues
     download: https://pypi.org/project/ANNarchy/

--- a/simtools/Arbor-GUI.yaml
+++ b/simtools/Arbor-GUI.yaml
@@ -23,7 +23,8 @@
     source: https://github.com/arbor-sim/gui
     email: contact@arbor-sim.org
     issue tracker: https://github.com/arbor-sim/gui/issues
-    download: https://docs.arbor-sim.org/en/latest/install/gui.html
+    installation: https://docs.arbor-sim.org/en/latest/install/gui.html
+    download: https://github.com/arbor-sim/gui/releases/
     forum: https://github.com/arbor-sim/arbor/discussions
     chat: https://gitter.im/arbor-sim/gui
 - relations:

--- a/simtools/Arbor.yaml
+++ b/simtools/Arbor.yaml
@@ -18,11 +18,13 @@
 - urls:
     homepage: https://arbor-sim.org
     documentation: https://docs.arbor-sim.org
-    tutorial: https://docs.arbor-sim.org/en/latest/tutorial
+    tutorial: https://docs.arbor-sim.org/en/stable/tutorial
+    examples: https://github.com/arbor-sim/arbor/tree/master/python/example
     source: https://github.com/arbor-sim/arbor
     email: contact@arbor-sim.org
     issue tracker: https://github.com/arbor-sim/arbor/issues
-    download: https://docs.arbor-sim.org/en/latest/install
+    installation: https://docs.arbor-sim.org/en/stable/install
+    download: https://pypi.org/project/arbor/
     forum: https://github.com/arbor-sim/arbor/discussions
     chat: https://gitter.im/arbor-sim/community
 - relations:

--- a/simtools/BMTK.yaml
+++ b/simtools/BMTK.yaml
@@ -1,6 +1,5 @@
 - name: Brain Modelling Toolkit (BMTK)
 - features: frontend
-- website_url: https://alleninstitute.github.io/bmtk/
 - operating_system: Linux, MacOS, Windows
 - biological_level: Population Model, Single-Compartment (Simple) Model, Single-Compartment (Complex) Model, Multi-Compartment Model
 - computing_scale: Single Machine, Cluster
@@ -23,3 +22,5 @@
 
     The BMTK was developed and is supported at the Allen Institute for Brain Science and released under a BSD 3-clause license.
     We encourage others to use the BMTK for their own research, and suggestions and contributions to the BMTK are welcome.
+- urls:
+      homepage: https://alleninstitute.github.io/bmtk/

--- a/simtools/BluePyOpt.yaml
+++ b/simtools/BluePyOpt.yaml
@@ -1,6 +1,5 @@
 - name: BluePyOpt
 - features: tool
-- website_url: https://bluepyopt.readthedocs.io
 - operating_system: Linux, MacOS, Windows
 - biological_level: Single-Compartment (Simple) Model, Single-Compartment (Complex) Model, Multi-Compartment Model
 - computing_scale: Single Machine
@@ -15,3 +14,6 @@
 
 
     Further, BluePyOpt provides methods for setting up both small- and large-scale optimisations on a variety of platforms, ranging from laptops to Linux clusters and cloud-based compute infrastructures.
+
+- urls:
+    homepage: https://bluepyopt.readthedocs.io

--- a/simtools/Brain-Scaffold-Builder.yaml
+++ b/simtools/Brain-Scaffold-Builder.yaml
@@ -1,6 +1,5 @@
 - name: Brain Scaffold Builder
 - features: frontend, backend
-- website_url: https://bsb.readthedocs.io
 - operating_system: Linux, MacOS, Windows
 - biological_level: #TODO
 - computing_scale: Single Machine
@@ -16,3 +15,6 @@
 
 
     This way, by implementing our component interfaces and declaring them in a configuration file, most models end up being code-free, well-parametrized, self-contained, human-readable, multi-scale models!
+
+- urls:
+    homepage: https://bsb.readthedocs.io

--- a/simtools/Brain-dynamics-toolbox.yaml
+++ b/simtools/Brain-dynamics-toolbox.yaml
@@ -1,6 +1,5 @@
 - name: Brain dynamics toolbox
 - features: frontend, backend
-- website_url: http://bdtoolbox.org/
 - operating_system: Linux, MacOS, Windows
 - biological_level: Population Model
 - computing_scale: Single Machine
@@ -10,3 +9,5 @@
     The Brain Dynamics Toolbox is open-source Matlab software for simulating bespoke dynamical systems in neuroscience and beyond.
     Users define their system of equations as a custom matlab function.
     Interchangeable solvers and plotting tools can then be applied to that system with no additional programming effort.
+- urls:
+      homepage: http://bdtoolbox.org/

--- a/simtools/Brian.yaml
+++ b/simtools/Brian.yaml
@@ -12,6 +12,9 @@
 - urls:
     homepage: https://briansimulator.org/
     documentation: https://brian2.readthedocs.io/
+    installation: https://brian2.readthedocs.io/en/stable/introduction/install.html
+    tutorial: https://brian2.readthedocs.io/en/stable/resources/tutorials/index.html
+    examples: https://brian2.readthedocs.io/en/stable/examples/index.html
     source: https://github.com/brian-team/brian2
     issue tracker: https://github.com/brian-team/brian2/issues
     download: https://pypi.org/project/Brian2/

--- a/simtools/Brian2CUDA.yaml
+++ b/simtools/Brian2CUDA.yaml
@@ -13,6 +13,7 @@
     - name: Brian
 - urls:
     documentation: https://brian2cuda.readthedocs.io
+    installation: https://brian2cuda.readthedocs.io/en/latest/introduction/install.html
     source: https://github.com/brian-team/brian2cuda
     issue tracker: https://github.com/brian-team/brian2cuda/issues
     download: https://pypi.org/project/Brian2CUDA/

--- a/simtools/Brian2GeNN.yaml
+++ b/simtools/Brian2GeNN.yaml
@@ -12,6 +12,7 @@
     - name: GeNN
 - urls:
     documentation: https://brian2genn.readthedocs.io
+    installation: https://brian2genn.readthedocs.io/en/stable/introduction/index.html#installing-the-brian2genn-interface
     source: https://github.com/brian-team/brian2genn
     issue tracker: https://github.com/brian-team/brian2genn/issues
     download: https://pypi.org/project/Brian2GeNN/

--- a/simtools/CoreNEURON.yaml
+++ b/simtools/CoreNEURON.yaml
@@ -1,6 +1,5 @@
 - name: CoreNEURON
 - features: backend
-- website_url: https://github.com/neuronsimulator/nrn/tree/master/src/coreneuron
 - operating_system: Linux, MacOS, Windows
 - biological_level: Single-Compartment (Simple) Model, Single-Compartment (Complex) Model, Multi-Compartment Model
 - computing_scale: Single Machine, Cluster, Supercomputer, GPU
@@ -11,3 +10,5 @@
     In order to run a NEURON model with CoreNEURON, MOD files should be THREADSAFE; If random number generator is used then Random123 should be used instead of MCellRan4; POINTER variables need to be converted to BBCOREPOINTER.
 - relations:
     - name: Neuron
+- urls:
+    homepage: https://github.com/neuronsimulator/nrn/tree/master/src/coreneuron

--- a/simtools/DiPDE.yaml
+++ b/simtools/DiPDE.yaml
@@ -1,6 +1,5 @@
 - name: DiPDE
 - features: frontend, backend
-- website_url: https://alleninstitute.github.io/dipde/index.html
 - operating_system: Linux, MacOS, Windows
 - biological_level: Population Model
 - computing_scale: Single Machine
@@ -10,3 +9,5 @@
     DiPDE (dipde) is a simulation platform for numerically solving the time evolution of coupled networks of neuronal populations.
     Instead of solving the subthreshold dynamics of individual model leaky-integrate-and-fire (LIF) neurons, dipde models the voltage distribution of a population of neurons with a single population density equation.
     In this way, dipde can facilitate the fast exploration of mesoscale (population-level) network topologies, where large populations of neurons are treated as homogeneous with random fine-scale connectivity.
+- urls:
+      homepage: https://alleninstitute.github.io/dipde/index.html

--- a/simtools/Eden.yaml
+++ b/simtools/Eden.yaml
@@ -10,3 +10,9 @@
     Extensible Dynamics Engine for Networks (EDEN) is a high-performance NeuroML-based neural simulator.
 - relations:
     - name: NeuroML
+- urls:
+      source: https://gitlab.com/c7859/neurocomputing-lab/Inferior_OliveEMC/eden
+      installation: https://gitlab.com/c7859/neurocomputing-lab/Inferior_OliveEMC/eden/-/tree/main#installing
+      examples: https://github.com/spanag/eden-sim-jupyter-demo
+      issue tracker: https://gitlab.com/c7859/neurocomputing-lab/Inferior_OliveEMC/eden/-/issues
+      download: https://pypi.org/project/eden-simulator/

--- a/simtools/Eden.yaml
+++ b/simtools/Eden.yaml
@@ -1,6 +1,5 @@
 - name: EDEN
 - features: backend
-- website_url: https://gitlab.com/neurocomputing-lab/Inferior_OliveEMC/eden
 - operating_system: Linux, MacOS, Windows
 - biological_level: Population Model, Single-Compartment (Simple) Model, Single-Compartment (Complex) Model, Multi-Compartment Model
 - computing_scale: Single Machine, Cluster

--- a/simtools/GeNN.yaml
+++ b/simtools/GeNN.yaml
@@ -11,6 +11,7 @@
 - urls:
     homepage: https://genn-team.github.io
     documentation: https://genn-team.github.io/genn/documentation/4/html/index.html
+    tutorial: https://genn-team.github.io/tutorials.html
     source: https://github.com/genn-team/genn
     forum: https://github.com/orgs/genn-team/discussions/categories/genn-questions
     issue tracker: https://github.com/genn-team/genn/issues

--- a/simtools/Genesis.yaml
+++ b/simtools/Genesis.yaml
@@ -1,6 +1,5 @@
 - name: GEneral NEural SImulation System (GENESIS)
 - features: frontend, backend
-- website_url: http://www.genesis-sim.org/
 - operating_system: Linux, MacOS, Windows
 - biological_level: Single-Compartment (Simple) Model, Single-Compartment (Complex) Model, Multi-Compartment Model
 - computing_scale: Single Machine
@@ -8,3 +7,5 @@
 - model_description_language:
 - summary: >
     GENESIS (the GEneral NEural SImulation System) is a general purpose simululation platform that was developed to support the simulation of neural systems ranging from subcellular components and biochemical reactions to complex models of single neurons, simulations of large networks, and system-level models.
+- urls:
+      homepage: http://www.genesis-sim.org/

--- a/simtools/Geppeto.yaml
+++ b/simtools/Geppeto.yaml
@@ -1,6 +1,5 @@
 - name: Geppeto
 - features: frontend
-- website_url: https://www.geppetto.org/
 - operating_system: Linux, MacOS, Windows
 - biological_level: #TODO
 - computing_scale: #TODO
@@ -10,3 +9,5 @@
     Geppetto is a web-based visualisation and simulation platform to build neuroscience software applications.
     Reuse best practices, best compomnents, best design.
     Don't reinvent the wheel.
+- urls:
+      homepage: https://www.geppetto.org/

--- a/simtools/Nest-GPU.yaml
+++ b/simtools/Nest-GPU.yaml
@@ -10,5 +10,9 @@
 - urls:
     homepage: https://nest-gpu.readthedocs.io
     documentation: https://nest-gpu.readthedocs.io
+    installation: https://nest-gpu.readthedocs.io/en/latest/installation/index.html
+    examples: https://nest-gpu.readthedocs.io/en/latest/examples/index.html
+    source: https://github.com/nest/nest-gpu
+    issue tracker: https://github.com/nest/nest-gpu/issues
 - relations:
     - name: NEST

--- a/simtools/Nest.yaml
+++ b/simtools/Nest.yaml
@@ -10,7 +10,12 @@
 - urls:
     homepage: https://nest-simulator.org
     source: https://github.com/nest/nest-simulator
+    installation: https://nest-simulator.readthedocs.io/en/stable/installation/index.html
     documentation: https://nest-simulator.org/documentation
+    tutorial: https://nest-simulator.readthedocs.io/en/stable/tutorials/index.html#tutorials
+    examples: https://nest-simulator.readthedocs.io/en/stable/examples/index.html#pynest-examples
+    issue tracker: https://nest-simulator.readthedocs.io/en/stable/developer_space/index.html#contribute
+    forum: https://nest-simulator.readthedocs.io/en/stable/developer_space/guidelines/mailing_list_guidelines.html#mail-guidelines
 - relations:
     - name: NEST GPU
     - name: NEST Desktop

--- a/simtools/NetPyNE.yaml
+++ b/simtools/NetPyNE.yaml
@@ -9,8 +9,11 @@
     NetPyNE is an open-source Python package to facilitate the development, parallel simulation, analysis, and optimization of biological neuronal networks using the NEURON simulator.
 - urls:
     homepage: http://www.netpyne.org/
+    installation: http://www.netpyne.org/install.html
+    tutorial: http://www.netpyne.org/tutorial.html
     source: https://github.com/suny-downstate-medical-center/netpyne
-    documentation: http://www.netpyne.org/
+    issue tracker: https://github.com/suny-downstate-medical-center/netpyne/issues
+    documentation: http://www.netpyne.org/user_documentation.html
 - relations:
     - name: Neuron
     - name: NeuroML

--- a/simtools/NeuroML.yaml
+++ b/simtools/NeuroML.yaml
@@ -28,6 +28,7 @@
 - urls:
     homepage: https://neuroml.org
     documentation: https://docs.neuroml.org
+    tutorial: https://docs.neuroml.org/Userdocs/GettingStarted.html
     source: https://github.com/NeuroML
     download: https://docs.neuroml.org/Userdocs/Software/Software.html
 - relations:

--- a/simtools/NeuroRD.yaml
+++ b/simtools/NeuroRD.yaml
@@ -1,6 +1,5 @@
 - name: NeuroRD
 - features: frontend, backend
-- website_url: https://krasnow1.gmu.edu/CENlab/software.html
 - operating_system: Linux, MacOS, Windows
 - biological_level: Single-Compartment (Complex) Model, Multi-Compartment Model
 - computing_scale: Single Machine
@@ -11,3 +10,5 @@
     This is a Java program which runs on any platform.
     The algorithm is based on Gillespie's tau-leap reaction algorithm, and the stochastic diffusion algorithm of Blackwell.
     It uses XML-based model specifications.
+- urls:
+      homepage: https://krasnow1.gmu.edu/CENlab/software.html

--- a/simtools/Neuron.yaml
+++ b/simtools/Neuron.yaml
@@ -10,6 +10,7 @@
     Build and simulate models using Python, HOC, and/or NEURON's graphical interface.
 - urls:
     homepage: https://neuron.yale.edu/neuron/
+    installation: https://nrn.readthedocs.io/en/latest/install/install.html
     source: https://github.com/neuronsimulator/nrn
     documentation: http://nrn.readthedocs.io/
     download: https://nrn.readthedocs.io/en/8.2.2/#installation

--- a/simtools/NeuronC.yaml
+++ b/simtools/NeuronC.yaml
@@ -1,6 +1,5 @@
 - name: NeuronC
 - features: frontend, backend
-- website_url: http://retina.anatomy.upenn.edu/~rob/neuronc.html
 - operating_system: Linux, MacOS
 - biological_level: Single-Compartment (Simple) Model, Single-Compartment (Complex) Model, Multi-Compartment Model
 - computing_scale: Single Machine
@@ -8,3 +7,5 @@
 - model_description_language: NeuronC Language
 - summary: >
     A neural circuit simulation language that allows a user to construct a realistic biophysically-based model of a neural circuit (1 to 10,000 neurons) and simulate a physiology experiment on it.
+- urls:
+      homepage: http://retina.anatomy.upenn.edu/~rob/neuronc.html

--- a/simtools/PyNN.yaml
+++ b/simtools/PyNN.yaml
@@ -23,7 +23,10 @@
     homepage: http://neuralensemble.org/PyNN/
     source: https://github.com/NeuralEnsemble/PyNN/
     documentation: http://neuralensemble.org/docs/PyNN/
-
+    installation: http://neuralensemble.org/docs/PyNN/installation.html
+    examples: http://neuralensemble.org/docs/PyNN/examples.html
+    forum: https://groups.google.com/forum/#!forum/neuralensemble
+    issue tracker: https://github.com/NeuralEnsemble/PyNN/issues
 - relations:
     - name: Neuron
     - name: NEST

--- a/simtools/README.md
+++ b/simtools/README.md
@@ -32,12 +32,11 @@ The `features` fields should contain one or more of the following values: `front
 interfaces to simulation engines), `backend` (for simulation engines), `standard`
 (for interoperability standards, APIs, etc.), or `tool` (for a general tool).
 
-The `urls` field can contain arbitrary keys that will be displayed as button
-labels. A  number of names will be recognized and will be displayed with a
-special icon: `homepage`, `source`, `documentation`, `issue tracker`,
-`download`, `release notes`, `email`, `chat`, and `forum`. The `email` field
-should refer to  an email address (which will be converted into a `mailto:`
-link), all other  fields should give a full URL.
+The `urls` field contains entries that will be displayed as button
+labels. The following names are recognized: `documentation`, `installation`, `tutorial`,
+`examples`, `email`, `chat`, `forum`, `issue tracker`, `source`, `download`.
+The `email` field  should refer to  an email address (which will be converted into a
+`mailto:` link), all other  fields should give a full URL.
 
 Relations are a list of other simulators that are related to the current
 simulator. The mentioned `name` needs to match the `name` of another simulator

--- a/simtools/ReMoto.yaml
+++ b/simtools/ReMoto.yaml
@@ -1,6 +1,5 @@
 - name: ReMoto
 - features: frontend, backend
-- website_url: http://remoto.leb.usp.br
 - operating_system: Linux, MacOS, Windows
 - biological_level: Population Model #TODO
 - computing_scale: Single Machine
@@ -12,3 +11,5 @@
     The simulator may be used to investigate phenomena at several levels of organization, e.g., at the neuronal membrane level or at the whole muscle behavior level (e.g., muscle force generation).
     This versatility arises because each element (neurons, synapses, muscle fibers) has its own specific mathematical model, usually involving the action of voltage- or neurotransmitter-dependent ionic channels.
     The simulator should be helpful in activities such as interpretation of results obtained from neurophysiological experiments in humans or mammals, proposal of hypothesis or testing models or theories on neuronal dynamics or neuronal network processing, validation of experimental protocols, and teaching neurophysiology.
+- urls:
+      homepage: http://remoto.leb.usp.br

--- a/simtools/SNNAP.yaml
+++ b/simtools/SNNAP.yaml
@@ -1,6 +1,5 @@
 - name: SNNAP
 - features: frontend, backend
-- website_url: https://med.uth.edu/nba/snnap/
 - operating_system: Linux, MacOS, Windows
 - biological_level: Population Model, Single-Compartment (Simple) Model, Single-Compartment (Complex) Model, Multi-Compartment Model
 - computing_scale: Single Machine
@@ -22,3 +21,5 @@
       - Graphical user interface
       - Ability to simulate common experimental manipulations.
       - Modular organizations of input files.
+- urls:
+      homepage: https://med.uth.edu/nba/snnap/

--- a/simtools/TheVirtualBrain-(TVB).yaml
+++ b/simtools/TheVirtualBrain-(TVB).yaml
@@ -17,3 +17,8 @@
 - urls:
     homepage: https://www.thevirtualbrain.org/
     source: https://github.com/the-virtual-brain/
+    documentation: http://docs.thevirtualbrain.org/
+    examples: https://github.com/the-virtual-brain/tvb-documentation/tree/master/demos
+    forum: https://groups.google.com/group/tvb-users/
+    issue tracker: http://req.thevirtualbrain.org/
+    download: https://www.thevirtualbrain.org/tvb/zwei/brainsimulator-software

--- a/simtools/nrn-patch.yaml
+++ b/simtools/nrn-patch.yaml
@@ -1,6 +1,5 @@
 - name: nrn-patch
 - features: frontend
-- website_url: https://github.com/dbbs-lab/patch
 - operating_system: #TODO
 - biological_level: #TODO
 - computing_scale: #TODO
@@ -10,3 +9,5 @@
     A Pythonic object-oriented drop-in replacement for the Python interface to NEURON.
 - relations:
     - name: Neuron
+- urls:
+      homepage: https://github.com/dbbs-lab/patch

--- a/src/project_browser.py
+++ b/src/project_browser.py
@@ -90,6 +90,12 @@ def get_icon(url_type, url):
             return "code"
     elif url_type.lower() == "documentation":
         return "book"
+    elif url_type.lower() == "tutorial":
+        return "school"
+    elif url_type.lower() == "installation":
+        return "device-laptop"
+    elif url_type.lower() == "examples":
+        return "script"
     elif url_type.lower() == "issue tracker":
         return "bug"
     elif url_type.lower() == "download":

--- a/src/project_browser.py
+++ b/src/project_browser.py
@@ -16,6 +16,35 @@ __version__ = "0.1.0"
 REPO_URL = "https://github.com/OCNS/simselect"
 DATA_FOLDER = "simtools"
 
+DOC_URLS = ["documentation", "installation", "tutorial", "examples"]
+DEV_URLS = ["email", "chat", "forum", "issue tracker", "source", "download"]
+
+
+def create_url_button(url_type, url, button_type="default"):
+    icon = get_icon(url_type, url)
+    url_button = pn.widgets.Button(
+        icon=icon,
+        name=url_type.capitalize(),
+        button_type=button_type,
+        stylesheets=["/assets/buttons.css"],
+    )
+    url_button.disabled = True if not url else False
+    if url_type.lower() == "email":
+        url_button.js_on_click(code=f"window.open('mailto:{url}')")
+    else:
+        url_button.js_on_click(code=f"window.open('{url}')")
+    return url_button
+
+
+def create_url_buttons(show_urls, simulator_urls, button_type):
+    url_buttons = []
+    for url_type in show_urls:
+        url_button = create_url_button(
+            url_type, simulator_urls.get(url_type, ""), button_type=button_type
+        )
+        url_buttons.append(url_button)
+    return url_buttons
+
 
 class SimButton(ReactiveHTML):
     sim_name = param.String()
@@ -255,21 +284,19 @@ class SimSelect:
 {criteria}
 """
         rows = [description]
-        url_buttons = []
-        for url_type, url in data.get("urls", {}).items():
-            icon = get_icon(url_type, url)
-            url_button = pn.widgets.Button(
-                icon=icon, name=url_type.capitalize(), button_type="default"
+        urls = data.get("urls", {})
+        if "homepage" in urls:
+            url_button = create_url_button(
+                "homepage", urls["homepage"], button_type="success"
             )
-            if url_type.lower() == "email":
-                url_button.js_on_click(code=f"window.open('mailto:{url}')")
-            else:
-                url_button.js_on_click(code=f"window.open('{url}')")
-            url_buttons.append(url_button)
+            # Display homepage prominently on its own (if it exists)
+            rows.append(pn.Row(url_button))
 
-        if url_buttons:
-            buttons = pn.Row(*url_buttons)
-            rows.append(buttons)
+        url_buttons = create_url_buttons(DOC_URLS, urls, "primary")
+        rows.append(pn.Row(*url_buttons))
+
+        url_buttons = create_url_buttons(DEV_URLS, urls, "default")
+        rows.append(pn.Row(*url_buttons))
 
         if data.get("relations", []):
             rows.append("## Related simulators")

--- a/tests/validate_data.py
+++ b/tests/validate_data.py
@@ -47,11 +47,26 @@ data_schema = Schema(
         },
         {
             Optional("urls"): {
-                str: str,
+                Or(
+                    "homepage",
+                    "documentation",
+                    "installation",
+                    "tutorial",
+                    "examples",
+                    "email",
+                    "chat",
+                    "forum",
+                    "issue tracker",
+                    "source",
+                    "download",
+                ): (
+                    lambda url: isinstance(url, str)
+                    and url.startswith("http")
+                    or "@" in url
+                )
             }
         },
         {Optional("relations"): [{"name": str}]},
-        {Optional("website_url"): str},
     ]
 )
 


### PR DESCRIPTION
This addresses most of the issues surrounding the "URL" buttons that we discussed during our meeting (closes #52).

A few notes:
- this now shows the homepage button prominently in Green first, if it exists – I decided to not show a grayed out homepage button if a tool doesn't have one, as I don't think it is strictly necessary to have a dedicated homepage if you have a good documentation, etc. Many projects use the homepage field on PyPI to link to the documentation or the github repo, but we have dedicated buttons for those
- I show the "user-facing" links (documentation, installation, tutorial, examples) first (and more prominent in blue), before showing in a second row the "where to get help" and development links
- I decided to not use "Getting started", since I did not find many simulators that had it, and some that had it were using it for what I'd call a tutorial
- Given that we now have a fixed set of url types (not final yet, e.g. no publications, etc.) that we show, I removed the feature to display arbitrary urls, and made the yaml schema more strict
- as a minor improvement, I also added a highlight around the currently selected simulator – maybe we could also highlight the other "related" simulators with a different color?

Here's what the URL buttons look like now for a simulator that specifies all of them:
![Screenshot 2023-07-27 at 14-17-58 SimSelect](https://github.com/OCNS/simselect/assets/1381982/49904a9b-26cb-4c13-88e9-7da6d7570eda)

And here for one with several entries missing:
![Screenshot 2023-07-27 at 14-18-39 SimSelect](https://github.com/OCNS/simselect/assets/1381982/8b4e7058-8c49-4baf-a993-7868614ba274)
