### PR TITLE
chore: fix push to production

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,10 +1,9 @@
 name: Fly Deploy
-on:
-  push:
-    branches:
-      - main
+on: [push]
+
 jobs:
   deploy_staging:  # Always deploy to staging
+    if: github.repository == 'OCNS/simselect' && github.ref == 'refs/heads/main'
     name: Deploy app to simselect-dev
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
+      with:
+          python-version: '3.11'
+          cache: 'pip'
+          cache-dependency-path: requirements.txt
     - name: Install dependencies
       run: python -m pip install -r requirements.txt -r requirements-dev.txt
     - name: Run pre-commit hooks

--- a/src/project_browser.py
+++ b/src/project_browser.py
@@ -11,7 +11,7 @@ import param
 import data
 
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 REPO_URL = "https://github.com/OCNS/simselect"
 DATA_FOLDER = "simtools"


### PR DESCRIPTION
Of course the "push to production" implemented #58 did *not* work, finally :rofl: 

The problem was that the action was only triggered for pushes to ``main``, but a tag does not count as being in the branch. I changed the action so that it runs unconditionally on pushes, and then only executes the job if in `main` (for pushes to `simselect-dev`) or if pushing a tag (for pushes to `simselect`).

I'll go ahead and merge this myself to try another release.