### PR TITLE
YAML simplification

### DIFF
--- a/simtools/ANNarchy.yaml
+++ b/simtools/ANNarchy.yaml
@@ -1,18 +1,16 @@
-- name: ANNarchy
-- features: frontend, simulator
-- operating_system: Linux, MacOS
-- biological_level: Population Model, Single-Compartment (Simple) Model, Single-Compartment (Complex) Model
-- processing_support: Single Machine, GPU
-- interface_language: Python, C++
-- summary: >
-    ANNarchy (Artificial Neural Networks architect) is a neural simulator designed for distributed rate-coded or spiking
-    neural networks. The core of the library is written in C++ and distributed using openMP or CUDA. It provides an
-    interface in Python for the definition of the networks.
-- urls:
-    documentation: https://annarchy.readthedocs.io
-    installation: https://annarchy.readthedocs.io/en/latest/Installation.html
-    examples: https://annarchy.readthedocs.io/en/latest/example/List.html
-    source: https://github.com/ANNarchy/ANNarchy
-    issue tracker: https://github.com/ANNarchy/ANNarchy/issues
-    download: https://pypi.org/project/ANNarchy/
-    forum: https://groups.google.com/forum/#!forum/annarchy
+name: ANNarchy
+features: frontend, simulator
+operating_system: Linux, MacOS
+biological_level: Population Model, Single-Compartment (Simple) Model, Single-Compartment (Complex) Model
+processing_support: Single Machine, GPU
+interface_language: Python, C++
+summary: |
+  ANNarchy (Artificial Neural Networks architect) is a neural simulator designed for distributed rate-coded or spiking neural networks. The core of the library is written in C++ and distributed using openMP or CUDA. It provides an interface in Python for the definition of the networks.
+urls:
+  documentation: https://annarchy.readthedocs.io
+  installation: https://annarchy.readthedocs.io/en/latest/Installation.html
+  examples: https://annarchy.readthedocs.io/en/latest/example/List.html
+  source: https://github.com/ANNarchy/ANNarchy
+  issue tracker: https://github.com/ANNarchy/ANNarchy/issues
+  download: https://pypi.org/project/ANNarchy/
+  forum: https://groups.google.com/forum/#!forum/annarchy

--- a/simtools/Arbor-GUI.yaml
+++ b/simtools/Arbor-GUI.yaml
@@ -1,29 +1,28 @@
-- name: Arbor GUI
-- features: frontend
-- operating_system: Linux, MacOS, Windows
-- interface_language: GUI
-- summary: >
-    Arbor GUI is a comprehensive tool for building single cell models using Arbor.
-    It strives to be self-contained, fast, and easy to use.
+name: Arbor GUI
+features: frontend
+operating_system: Linux, MacOS, Windows
+interface_language: GUI
+summary: |
+  Arbor GUI is a comprehensive tool for building single cell models using Arbor.
+  It strives to be self-contained, fast, and easy to use.
 
-
-     - Design morphologically detailled cells for simulation in Arbor.
-     - Load morphologies from SWC .swc, NeuroML .nml, NeuroLucida .asc.
-     - Define and highlight Arbor regions and locsets.
-     - Paint ion dynamics and bio-physical properties onto morphologies.
-     - Place spike detectors and probes.
-     - Export cable cells to Arbor’s internal format (ACC) for direct simulation.
-     - Import cable cells in ACC format
-- urls:
-    homepage: https://github.com/arbor-sim/gui
-    tutorial: https://docs.arbor-sim.org/en/latest/tutorial/single_cell_gui.html
-    source: https://github.com/arbor-sim/gui
-    email: contact@arbor-sim.org
-    issue tracker: https://github.com/arbor-sim/gui/issues
-    installation: https://docs.arbor-sim.org/en/latest/install/gui.html
-    download: https://github.com/arbor-sim/gui/releases/
-    forum: https://github.com/arbor-sim/arbor/discussions
-    chat: https://gitter.im/arbor-sim/gui
-- relations:
-  - name: Arbor
-    description: GUI for
+   - Design morphologically detailled cells for simulation in Arbor.
+   - Load morphologies from SWC .swc, NeuroML .nml, NeuroLucida .asc.
+   - Define and highlight Arbor regions and locsets.
+   - Paint ion dynamics and bio-physical properties onto morphologies.
+   - Place spike detectors and probes.
+   - Export cable cells to Arbor’s internal format (ACC) for direct simulation.
+   - Import cable cells in ACC format
+urls:
+  homepage: https://github.com/arbor-sim/gui
+  tutorial: https://docs.arbor-sim.org/en/latest/tutorial/single_cell_gui.html
+  source: https://github.com/arbor-sim/gui
+  email: contact@arbor-sim.org
+  issue tracker: https://github.com/arbor-sim/gui/issues
+  installation: https://docs.arbor-sim.org/en/latest/install/gui.html
+  download: https://github.com/arbor-sim/gui/releases/
+  forum: https://github.com/arbor-sim/arbor/discussions
+  chat: https://gitter.im/arbor-sim/gui
+relations:
+- name: Arbor
+  description: GUI for

--- a/simtools/Arbor-Playground.yaml
+++ b/simtools/Arbor-Playground.yaml
@@ -1,13 +1,13 @@
-- name: Arbor Playground
-- features: frontend
-- operating_system: Linux, MacOS, Windows
-- interface_language: GUI, Python
-- summary: Arbor Playground is an Emscripten + Pyodide port of Arbor and is meant to be a simple showcase of neural modelling in Arbor.
-- urls:
-    homepage: https://arbor-sim.org/playground
-    documentation: https://docs.arbor-sim.org
-    source: https://github.com/arbor-sim/playground
-    email: contact@arbor-sim.org
-    issue tracker: https://github.com/arbor-sim/playground/issues
-    forum: https://github.com/arbor-sim/arbor/discussions
-    chat: https://gitter.im/arbor-sim/community
+name: Arbor Playground
+features: frontend
+operating_system: Linux, MacOS, Windows
+interface_language: GUI, Python
+summary: Arbor Playground is an Emscripten + Pyodide port of Arbor and is meant to be a simple showcase of neural modelling in Arbor.
+urls:
+  homepage: https://arbor-sim.org/playground
+  documentation: https://docs.arbor-sim.org
+  source: https://github.com/arbor-sim/playground
+  email: contact@arbor-sim.org
+  issue tracker: https://github.com/arbor-sim/playground/issues
+  forum: https://github.com/arbor-sim/arbor/discussions
+  chat: https://gitter.im/arbor-sim/community

--- a/simtools/Arbor.yaml
+++ b/simtools/Arbor.yaml
@@ -1,28 +1,28 @@
-- name: Arbor
-- features: frontend, simulator
-- operating_system: Linux, MacOS, Windows
-- biological_level: Population Model, Single-Compartment (Simple) Model, Single-Compartment (Complex) Model, Multi-Compartment Model
-- processing_support: Single Machine, Cluster, Supercomputer, GPU
-- interface_language: Python, C++
-- summary: >
-    Arbor is a high-performance library for computational neuroscience simulations with multi-compartment, morphologically-detailed cells, from single cell models to very large networks.
-    Arbor is written from the ground up with many-cpu and gpu architectures in mind, to help neuroscientists effectively use contemporary and future HPC systems to meet their simulation needs.
+name: Arbor
+features: frontend, simulator
+operating_system: Linux, MacOS, Windows
+biological_level: Population Model, Single-Compartment (Simple) Model, Single-Compartment (Complex) Model, Multi-Compartment Model
+processing_support: Single Machine, Cluster, Supercomputer, GPU
+interface_language: Python, C++
+summary: |
+  Arbor is a high-performance library for computational neuroscience simulations with multi-compartment, morphologically-detailed cells, from single cell models to very large networks.
+  Arbor is written from the ground up with many-cpu and gpu architectures in mind, to help neuroscientists effectively use contemporary and future HPC systems to meet their simulation needs.
 
 
-    Arbor supports NVIDIA and AMD GPUs as well as explicit vectorization on CPUs from Intel (AVX, AVX2 and AVX512) and ARM (Neon and SVE).
-    When coupled with low memory overheads, this makes Arbor an order of magnitude faster than the most widely-used comparable simulation software.
+  Arbor supports NVIDIA and AMD GPUs as well as explicit vectorization on CPUs from Intel (AVX, AVX2 and AVX512) and ARM (Neon and SVE).
+  When coupled with low memory overheads, this makes Arbor an order of magnitude faster than the most widely-used comparable simulation software.
 
 
-    Arbor is open source and openly developed, and we use development practices such as unit testing, continuous integration, and validation.
-- urls:
-    homepage: https://arbor-sim.org
-    documentation: https://docs.arbor-sim.org
-    tutorial: https://docs.arbor-sim.org/en/stable/tutorial
-    examples: https://github.com/arbor-sim/arbor/tree/master/python/example
-    source: https://github.com/arbor-sim/arbor
-    email: contact@arbor-sim.org
-    issue tracker: https://github.com/arbor-sim/arbor/issues
-    installation: https://docs.arbor-sim.org/en/stable/install
-    download: https://pypi.org/project/arbor/
-    forum: https://github.com/arbor-sim/arbor/discussions
-    chat: https://gitter.im/arbor-sim/community
+  Arbor is open source and openly developed, and we use development practices such as unit testing, continuous integration, and validation.
+urls:
+  homepage: https://arbor-sim.org
+  documentation: https://docs.arbor-sim.org
+  tutorial: https://docs.arbor-sim.org/en/stable/tutorial
+  examples: https://github.com/arbor-sim/arbor/tree/master/python/example
+  source: https://github.com/arbor-sim/arbor
+  email: contact@arbor-sim.org
+  issue tracker: https://github.com/arbor-sim/arbor/issues
+  installation: https://docs.arbor-sim.org/en/stable/install
+  download: https://pypi.org/project/arbor/
+  forum: https://github.com/arbor-sim/arbor/discussions
+  chat: https://gitter.im/arbor-sim/community

--- a/simtools/BMTK.yaml
+++ b/simtools/BMTK.yaml
@@ -1,27 +1,24 @@
-- name: Brain Modelling Toolkit (BMTK)
-- short_name: BMTK
-- features: frontend
-- operating_system: Linux, MacOS, Windows
-- interface_language: Python
-- summary: >
-    The Brain Modeling Toolkit (BMTK) is a python-based software package for building, simulating and analyzing large-scale neural network models.
-    It supports the building and simulation of models of varying levels-of-resolution; from multi-compartment biophysically detailed networks, to point-neuron models, to filter-based models, and even population-level firing rate models.
+name: Brain Modelling Toolkit (BMTK)
+short_name: BMTK
+features: frontend
+operating_system: Linux, MacOS, Windows
+interface_language: Python
+summary: |
+  The Brain Modeling Toolkit (BMTK) is a python-based software package for building, simulating and analyzing large-scale neural network models.
+  It supports the building and simulation of models of varying levels-of-resolution; from multi-compartment biophysically detailed networks, to point-neuron models, to filter-based models, and even population-level firing rate models.
 
+  The BMTK is not itself a simulator and will utilize existing simulators, like NEURON and NEST, to run different types of models.
+  What BMTK does provide:
 
-    The BMTK is not itself a simulator and will utilize existing simulators, like NEURON and NEST, to run different types of models.
-    What BMTK does provide:
+    - A unified interface across different simulators, so that modelers can work with and study their own network models across different simulators without having to learn how to use each tool.
+    - An easy way to setup and initialize network simulations with little-to-no programming necessary
+    - Automatic integration of parallelization when running on HPC.
+    - Extra built-in features which the native simulators may not support out-of-the-box.
 
-
-      - A unified interface across different simulators, so that modelers can work with and study their own network models across different simulators without having to learn how to use each tool.
-      - An easy way to setup and initialize network simulations with little-to-no programming necessary
-      - Automatic integration of parallelization when running on HPC.
-      - Extra built-in features which the native simulators may not support out-of-the-box.
-
-
-    The BMTK was developed and is supported at the Allen Institute for Brain Science and released under a BSD 3-clause license.
-    We encourage others to use the BMTK for their own research, and suggestions and contributions to the BMTK are welcome.
-- urls:
-      homepage: https://alleninstitute.github.io/bmtk/
-- relations:
-  - name: SONATA
-    description: exports to
+  The BMTK was developed and is supported at the Allen Institute for Brain Science and released under a BSD 3-clause license.
+  We encourage others to use the BMTK for their own research, and suggestions and contributions to the BMTK are welcome.
+urls:
+    homepage: https://alleninstitute.github.io/bmtk/
+relations:
+- name: SONATA
+  description: exports to

--- a/simtools/BluePyOpt.yaml
+++ b/simtools/BluePyOpt.yaml
@@ -1,19 +1,16 @@
-- name: BluePyOpt
-- features: tool
-- operating_system: Linux, MacOS, Windows
-- interface_language: Python
-- summary: >
-    The Blue Brain Python Optimisation Library (BluePyOpt) is an extensible framework for data-driven model parameter optimisation that wraps and standardises several existing open-source tools.
+name: BluePyOpt
+features: tool
+operating_system: Linux, MacOS, Windows
+interface_language: Python
+summary: |
+  The Blue Brain Python Optimisation Library (BluePyOpt) is an extensible framework for data-driven model parameter optimisation that wraps and standardises several existing open-source tools.
 
+  It simplifies the task of creating and sharing these optimisations, and the associated techniques and knowledge.
+  This is achieved by abstracting the optimisation and evaluation tasks into various reusable and flexible discrete elements according to established best-practices.
 
-    It simplifies the task of creating and sharing these optimisations, and the associated techniques and knowledge.
-    This is achieved by abstracting the optimisation and evaluation tasks into various reusable and flexible discrete elements according to established best-practices.
-
-
-    Further, BluePyOpt provides methods for setting up both small- and large-scale optimisations on a variety of platforms, ranging from laptops to Linux clusters and cloud-based compute infrastructures.
-
-- urls:
-    homepage: https://bluepyopt.readthedocs.io
-- relations:
-    - name: NeuroML
-      description: exports to
+  Further, BluePyOpt provides methods for setting up both small- and large-scale optimisations on a variety of platforms, ranging from laptops to Linux clusters and cloud-based compute infrastructures.
+urls:
+  homepage: https://bluepyopt.readthedocs.io
+relations:
+  - name: NeuroML
+    description: exports to

--- a/simtools/Brain-Scaffold-Builder.yaml
+++ b/simtools/Brain-Scaffold-Builder.yaml
@@ -1,24 +1,21 @@
-- name: Brain Scaffold Builder
-- features: frontend
-- operating_system: Linux, MacOS, Windows
-- interface_language: Python
-- summary: >
-    The Brain Scaffold Builder (BSB) is a black box component framework for multiparadigm neural modelling: we provide structure, architecture and organization, and you provide the use-case specific parts of your model.
-    In our framework, your model is described in a code-free configuration of components with parameters.
+name: Brain Scaffold Builder
+features: frontend
+operating_system: Linux, MacOS, Windows
+interface_language: Python
+summary: |
+  The Brain Scaffold Builder (BSB) is a black box component framework for multiparadigm neural modelling: we provide structure, architecture and organization, and you provide the use-case specific parts of your model.
+  In our framework, your model is described in a code-free configuration of components with parameters.
 
+  For the framework to reliably use components, and make them work together in a complex workflow, it asks a fixed set of questions per component type: e.g. a connection component will be asked how to connect cells.
+  These contracts of cooperation between you and the framework are called interfaces. The framework executes a transparently parallelized workflow, and calls your components to fulfill their role.
 
-    For the framework to reliably use components, and make them work together in a complex workflow, it asks a fixed set of questions per component type: e.g. a connection component will be asked how to connect cells.
-    These contracts of cooperation between you and the framework are called interfaces. The framework executes a transparently parallelized workflow, and calls your components to fulfill their role.
-
-
-    This way, by implementing our component interfaces and declaring them in a configuration file, most models end up being code-free, well-parametrized, self-contained, human-readable, multi-scale models!
-
-- urls:
-    homepage: https://bsb.readthedocs.io
-- relations:
-    - name: Neuron
-      description: simulates with
-    - name: NEST
-      description: simulates with
-    - name: Arbor
-      description: simulates with
+  This way, by implementing our component interfaces and declaring them in a configuration file, most models end up being code-free, well-parametrized, self-contained, human-readable, multi-scale models!
+urls:
+  homepage: https://bsb.readthedocs.io
+relations:
+  - name: Neuron
+    description: simulates with
+  - name: NEST
+    description: simulates with
+  - name: Arbor
+    description: simulates with

--- a/simtools/Brain-dynamics-toolbox.yaml
+++ b/simtools/Brain-dynamics-toolbox.yaml
@@ -1,12 +1,12 @@
-- name: Brain dynamics toolbox
-- features: frontend, simulator
-- operating_system: Linux, MacOS, Windows
-- biological_level: Population Model
-- processing_support: Single Machine
-- interface_language: MATLAB
-- summary: >
-    The Brain Dynamics Toolbox is open-source Matlab software for simulating bespoke dynamical systems in neuroscience and beyond.
-    Users define their system of equations as a custom matlab function.
-    Interchangeable solvers and plotting tools can then be applied to that system with no additional programming effort.
-- urls:
-      homepage: http://bdtoolbox.org/
+name: Brain dynamics toolbox
+features: frontend, simulator
+operating_system: Linux, MacOS, Windows
+biological_level: Population Model
+processing_support: Single Machine
+interface_language: MATLAB
+summary: |
+  The Brain Dynamics Toolbox is open-source Matlab software for simulating bespoke dynamical systems in neuroscience and beyond.
+  Users define their system of equations as a custom matlab function.
+  Interchangeable solvers and plotting tools can then be applied to that system with no additional programming effort.
+urls:
+    homepage: http://bdtoolbox.org/

--- a/simtools/Brian.yaml
+++ b/simtools/Brian.yaml
@@ -1,22 +1,22 @@
-- name: Brian
-- features: frontend, simulator
-- operating_system: Linux, MacOS, Windows
-- biological_level: Population Model, Single-Compartment (Simple) Model, Single-Compartment (Complex) Model, Multi-Compartment Model
-- processing_support: Single Machine, Cluster
-- interface_language: Python
-- summary: >
-    Brian is a free, open source simulator for spiking neural networks. It is written in the Python programming language
-    and is available on almost all platforms. We believe that a simulator should not only save the time of processors,
-    but also the time of scientists. Brian is therefore designed to be easy to learn and use, highly flexible and easily
-    extensible.
-- urls:
-    homepage: https://briansimulator.org/
-    documentation: https://brian2.readthedocs.io/
-    installation: https://brian2.readthedocs.io/en/stable/introduction/install.html
-    tutorial: https://brian2.readthedocs.io/en/stable/resources/tutorials/index.html
-    examples: https://brian2.readthedocs.io/en/stable/examples/index.html
-    source: https://github.com/brian-team/brian2
-    issue tracker: https://github.com/brian-team/brian2/issues
-    download: https://pypi.org/project/Brian2/
-    forum: https://brian.discourse.group
-    chat: https://gitter.im/brian-team/brian2
+name: Brian
+features: frontend, simulator
+operating_system: Linux, MacOS, Windows
+biological_level: Population Model, Single-Compartment (Simple) Model, Single-Compartment (Complex) Model, Multi-Compartment Model
+processing_support: Single Machine, Cluster
+interface_language: Python
+summary: |
+  Brian is a free, open source simulator for spiking neural networks. It is written in the Python programming language
+  and is available on almost all platforms. We believe that a simulator should not only save the time of processors,
+  but also the time of scientists. Brian is therefore designed to be easy to learn and use, highly flexible and easily
+  extensible.
+urls:
+  homepage: https://briansimulator.org/
+  documentation: https://brian2.readthedocs.io/
+  installation: https://brian2.readthedocs.io/en/stable/introduction/install.html
+  tutorial: https://brian2.readthedocs.io/en/stable/resources/tutorials/index.html
+  examples: https://brian2.readthedocs.io/en/stable/examples/index.html
+  source: https://github.com/brian-team/brian2
+  issue tracker: https://github.com/brian-team/brian2/issues
+  download: https://pypi.org/project/Brian2/
+  forum: https://brian.discourse.group
+  chat: https://gitter.im/brian-team/brian2

--- a/simtools/Brian2CUDA.yaml
+++ b/simtools/Brian2CUDA.yaml
@@ -1,20 +1,20 @@
-- name: Brian2CUDA
-- features: library
-- operating_system: Linux, MacOS
-- biological_level: Population Model, Single-Compartment (Simple) Model, Single-Compartment (Complex) Model, Multi-Compartment Model
-- processing_support: GPU
-- interface_language: Python
-- summary: >
-    Brian2CUDA is a Python package for simulating spiking neural networks on graphics processing units (GPUs).
-    It is an extension of the spiking neural network simulator Brian2, which allows flexible model definitions in
-    Python. Brian2CUDA uses the code generation system from Brian2 to generate simulation code in C++/CUDA, which is
-    then executed on NVIDIA GPUs.
-- relations:
-    - name: Brian
-      description: simulates
-- urls:
-    documentation: https://brian2cuda.readthedocs.io
-    installation: https://brian2cuda.readthedocs.io/en/latest/introduction/install.html
-    source: https://github.com/brian-team/brian2cuda
-    issue tracker: https://github.com/brian-team/brian2cuda/issues
-    download: https://pypi.org/project/Brian2CUDA/
+name: Brian2CUDA
+features: library
+operating_system: Linux, MacOS
+biological_level: Population Model, Single-Compartment (Simple) Model, Single-Compartment (Complex) Model, Multi-Compartment Model
+processing_support: GPU
+interface_language: Python
+summary: |
+  Brian2CUDA is a Python package for simulating spiking neural networks on graphics processing units (GPUs).
+  It is an extension of the spiking neural network simulator Brian2, which allows flexible model definitions in
+  Python. Brian2CUDA uses the code generation system from Brian2 to generate simulation code in C++/CUDA, which is
+  then executed on NVIDIA GPUs.
+relations:
+  - name: Brian
+    description: simulates
+urls:
+  documentation: https://brian2cuda.readthedocs.io
+  installation: https://brian2cuda.readthedocs.io/en/latest/introduction/install.html
+  source: https://github.com/brian-team/brian2cuda
+  issue tracker: https://github.com/brian-team/brian2cuda/issues
+  download: https://pypi.org/project/Brian2CUDA/

--- a/simtools/Brian2CUDA.yaml
+++ b/simtools/Brian2CUDA.yaml
@@ -1,7 +1,6 @@
 name: Brian2CUDA
 features: library
 operating_system: Linux, MacOS
-biological_level: Population Model, Single-Compartment (Simple) Model, Single-Compartment (Complex) Model, Multi-Compartment Model
 processing_support: GPU
 interface_language: Python
 summary: |

--- a/simtools/Brian2GeNN.yaml
+++ b/simtools/Brian2GeNN.yaml
@@ -1,18 +1,18 @@
-- name: Brian2GeNN
-- features: library
-- operating_system: Linux, MacOS, Windows
-- interface_language: Python
-- summary: >
-    Brian2GeNN connects Brian 2 to the GeNN simulator, so that users can make use of GeNN GPU acceleration when
-    developing their models in Brian, without requiring any technical knowledge about GPUs, C++ or GeNN.
-- relations:
-    - name: Brian
-      description: converts from
-    - name: GeNN
-      description: exports to
-- urls:
-    documentation: https://brian2genn.readthedocs.io
-    installation: https://brian2genn.readthedocs.io/en/stable/introduction/index.html#installing-the-brian2genn-interface
-    source: https://github.com/brian-team/brian2genn
-    issue tracker: https://github.com/brian-team/brian2genn/issues
-    download: https://pypi.org/project/Brian2GeNN/
+name: Brian2GeNN
+features: library
+operating_system: Linux, MacOS, Windows
+interface_language: Python
+summary: |
+  Brian2GeNN connects Brian 2 to the GeNN simulator, so that users can make use of GeNN GPU acceleration when
+  developing their models in Brian, without requiring any technical knowledge about GPUs, C++ or GeNN.
+relations:
+  - name: Brian
+    description: converts from
+  - name: GeNN
+    description: exports to
+urls:
+  documentation: https://brian2genn.readthedocs.io
+  installation: https://brian2genn.readthedocs.io/en/stable/introduction/index.html#installing-the-brian2genn-interface
+  source: https://github.com/brian-team/brian2genn
+  issue tracker: https://github.com/brian-team/brian2genn/issues
+  download: https://pypi.org/project/Brian2GeNN/

--- a/simtools/DiPDE.yaml
+++ b/simtools/DiPDE.yaml
@@ -1,12 +1,12 @@
-- name: DiPDE
-- features: frontend, simulator
-- operating_system: Linux, MacOS, Windows
-- biological_level: Population Model
-- processing_support: Single Machine
-- interface_language: Python
-- summary: >
-    DiPDE (dipde) is a simulation platform for numerically solving the time evolution of coupled networks of neuronal populations.
-    Instead of solving the subthreshold dynamics of individual model leaky-integrate-and-fire (LIF) neurons, dipde models the voltage distribution of a population of neurons with a single population density equation.
-    In this way, dipde can facilitate the fast exploration of mesoscale (population-level) network topologies, where large populations of neurons are treated as homogeneous with random fine-scale connectivity.
-- urls:
-      homepage: https://alleninstitute.github.io/dipde/index.html
+name: DiPDE
+features: frontend, simulator
+operating_system: Linux, MacOS, Windows
+biological_level: Population Model
+processing_support: Single Machine
+interface_language: Python
+summary: |
+  DiPDE (dipde) is a simulation platform for numerically solving the time evolution of coupled networks of neuronal populations.
+  Instead of solving the subthreshold dynamics of individual model leaky-integrate-and-fire (LIF) neurons, dipde models the voltage distribution of a population of neurons with a single population density equation.
+  In this way, dipde can facilitate the fast exploration of mesoscale (population-level) network topologies, where large populations of neurons are treated as homogeneous with random fine-scale connectivity.
+urls:
+    homepage: https://alleninstitute.github.io/dipde/index.html

--- a/simtools/EDEN.yaml
+++ b/simtools/EDEN.yaml
@@ -1,14 +1,14 @@
-- name: EDEN
-- features: simulator
-- operating_system: Linux, MacOS, Windows
-- biological_level: Population Model, Single-Compartment (Simple) Model, Single-Compartment (Complex) Model, Multi-Compartment Model
-- processing_support: Single Machine, Cluster
-- interface_language: CLI, Python
-- summary: >
-    Extensible Dynamics Engine for Networks (EDEN) is a high-performance NeuroML-based neural simulator.
-- urls:
-      source: https://gitlab.com/c7859/neurocomputing-lab/Inferior_OliveEMC/eden
-      installation: https://gitlab.com/c7859/neurocomputing-lab/Inferior_OliveEMC/eden/-/tree/main#installing
-      examples: https://github.com/spanag/eden-sim-jupyter-demo
-      issue tracker: https://gitlab.com/c7859/neurocomputing-lab/Inferior_OliveEMC/eden/-/issues
-      download: https://pypi.org/project/eden-simulator/
+name: EDEN
+features: simulator
+operating_system: Linux, MacOS, Windows
+biological_level: Population Model, Single-Compartment (Simple) Model, Single-Compartment (Complex) Model, Multi-Compartment Model
+processing_support: Single Machine, Cluster
+interface_language: CLI, Python
+summary: |
+  Extensible Dynamics Engine for Networks (EDEN) is a high-performance NeuroML-based neural simulator.
+urls:
+    source: https://gitlab.com/c7859/neurocomputing-lab/Inferior_OliveEMC/eden
+    installation: https://gitlab.com/c7859/neurocomputing-lab/Inferior_OliveEMC/eden/-/tree/main#installing
+    examples: https://github.com/spanag/eden-sim-jupyter-demo
+    issue tracker: https://gitlab.com/c7859/neurocomputing-lab/Inferior_OliveEMC/eden/-/issues
+    download: https://pypi.org/project/eden-simulator/

--- a/simtools/GENESIS.yaml
+++ b/simtools/GENESIS.yaml
@@ -1,11 +1,11 @@
-- name: GEneral NEural SImulation System (GENESIS)
-- short_name: GENESIS
-- features: frontend, simulator
-- operating_system: Linux, MacOS, Windows
-- biological_level: Single-Compartment (Simple) Model, Single-Compartment (Complex) Model, Multi-Compartment Model
-- processing_support: Single Machine
-- interface_language: GUI, C
-- summary: >
-    GENESIS (the GEneral NEural SImulation System) is a general purpose simululation platform that was developed to support the simulation of neural systems ranging from subcellular components and biochemical reactions to complex models of single neurons, simulations of large networks, and system-level models.
-- urls:
-      homepage: http://www.genesis-sim.org/
+name: GEneral NEural SImulation System (GENESIS)
+short_name: GENESIS
+features: frontend, simulator
+operating_system: Linux, MacOS, Windows
+biological_level: Single-Compartment (Simple) Model, Single-Compartment (Complex) Model, Multi-Compartment Model
+processing_support: Single Machine
+interface_language: GUI, C
+summary: |
+  GENESIS (the GEneral NEural SImulation System) is a general purpose simululation platform that was developed to support the simulation of neural systems ranging from subcellular components and biochemical reactions to complex models of single neurons, simulations of large networks, and system-level models.
+urls:
+    homepage: http://www.genesis-sim.org/

--- a/simtools/GeNN.yaml
+++ b/simtools/GeNN.yaml
@@ -1,15 +1,15 @@
-- name: GeNN
-- features: frontend, simulator
-- operating_system: Linux, MacOS, Windows
-- biological_level: Population Model, Single-Compartment (Simple) Model, Single-Compartment (Complex) Model
-- processing_support: Single Machine, GPU
-- interface_language: Python, C++
-- summary: >
-    GeNN is a GPU enhanced Neuronal Network simulation environment based on NVIDIA CUDA technology.
-- urls:
-    homepage: https://genn-team.github.io
-    documentation: https://genn-team.github.io/genn/documentation/4/html/index.html
-    tutorial: https://genn-team.github.io/tutorials.html
-    source: https://github.com/genn-team/genn
-    forum: https://github.com/orgs/genn-team/discussions/categories/genn-questions
-    issue tracker: https://github.com/genn-team/genn/issues
+name: GeNN
+features: frontend, simulator
+operating_system: Linux, MacOS, Windows
+biological_level: Population Model, Single-Compartment (Simple) Model, Single-Compartment (Complex) Model
+processing_support: Single Machine, GPU
+interface_language: Python, C++
+summary: |
+  GeNN is a GPU enhanced Neuronal Network simulation environment based on NVIDIA CUDA technology.
+urls:
+  homepage: https://genn-team.github.io
+  documentation: https://genn-team.github.io/genn/documentation/4/html/index.html
+  tutorial: https://genn-team.github.io/tutorials.html
+  source: https://github.com/genn-team/genn
+  forum: https://github.com/orgs/genn-team/discussions/categories/genn-questions
+  issue tracker: https://github.com/genn-team/genn/issues

--- a/simtools/Geppeto.yaml
+++ b/simtools/Geppeto.yaml
@@ -1,10 +1,10 @@
-- name: Geppeto
-- features: frontend
-- operating_system: Linux, MacOS, Windows
-- interface_language: Python, Javascript
-- summary: >
-    Geppetto is a web-based visualisation and simulation platform to build neuroscience software applications.
-    Reuse best practices, best compomnents, best design.
-    Don't reinvent the wheel.
-- urls:
-      homepage: https://www.geppetto.org/
+name: Geppeto
+features: frontend
+operating_system: Linux, MacOS, Windows
+interface_language: Python, Javascript
+summary: |
+  Geppetto is a web-based visualisation and simulation platform to build neuroscience software applications.
+  Reuse best practices, best compomnents, best design.
+  Don't reinvent the wheel.
+urls:
+    homepage: https://www.geppetto.org/

--- a/simtools/LFPy.yaml
+++ b/simtools/LFPy.yaml
@@ -1,15 +1,15 @@
-- name: LFPy
-- features: tool
-- operating_system: Linux, MacOS, Windows
-- interface_language: Python
-- summary: >
-    LFPy is a Python module for calculation of extracellular potentials from multicompartment neuron models.
-    It relies on the NEURON simulator and uses the Python interface it provides.
-- urls:
-    homepage: https://lfpy.readthedocs.io/en/latest/
-    documentation: https://lfpy.readthedocs.io/en/latest/
-    source: https://github.com/LFPy/LFPy/
-    download: https://pypi.org/project/LFPy/
-- relations:
-    - name: Neuron
-      description: simulates with
+name: LFPy
+features: tool
+operating_system: Linux, MacOS, Windows
+interface_language: Python
+summary: |
+  LFPy is a Python module for calculation of extracellular potentials from multicompartment neuron models.
+  It relies on the NEURON simulator and uses the Python interface it provides.
+urls:
+  homepage: https://lfpy.readthedocs.io/en/latest/
+  documentation: https://lfpy.readthedocs.io/en/latest/
+  source: https://github.com/LFPy/LFPy/
+  download: https://pypi.org/project/LFPy/
+relations:
+  - name: Neuron
+    description: simulates with

--- a/simtools/MOOSE.yaml
+++ b/simtools/MOOSE.yaml
@@ -1,22 +1,22 @@
-- name: MOOSE
-- features: frontend, simulator
-- operating_system: Linux, MacOS
-- biological_level: Population Model, Single-Compartment (Simple) Model, Single-Compartment (Complex) Model, Multi-Compartment Model
-- processing_support: Single Machine, Cluster, Supercomputer, GPU
-- interface_language: Python, GUI, C++
-- summary: >
-    MOOSE is the Multiscale Object-Oriented Simulation Environment.
-    It is designed to simulate neural systems ranging from subcellular components and biochemical reactions to complex models of single neurons, circuits, and large networks.
-    MOOSE can operate at many levels of detail, from stochastic chemical computations, to multicompartment single-neuron models, to spiking neuron network models.
+name: MOOSE
+features: frontend, simulator
+operating_system: Linux, MacOS
+biological_level: Population Model, Single-Compartment (Simple) Model, Single-Compartment (Complex) Model, Multi-Compartment Model
+processing_support: Single Machine, Cluster, Supercomputer, GPU
+interface_language: Python, GUI, C++
+summary: |
+  MOOSE is the Multiscale Object-Oriented Simulation Environment.
+  It is designed to simulate neural systems ranging from subcellular components and biochemical reactions to complex models of single neurons, circuits, and large networks.
+  MOOSE can operate at many levels of detail, from stochastic chemical computations, to multicompartment single-neuron models, to spiking neuron network models.
 
 
-    MOOSE is a simulation environment, not just a numerical engine.
-    It provides the essentials by way of object-oriented representations of model concepts and fast numerical solvers, but its scope is much broader.
-    It has a scripting interface with Python, graphical displays with Matplotlib, PyQt, and OpenGL, and support for many model formats.
-- urls:
-    homepage: https://moose.ncbs.res.in/
-    source: https://github.com/BhallaLab/moose
-    documentation: https://moose.ncbs.res.in/readthedocs/index.html
-- relations:
-    - name: NeuroML
-      description: can import, can export to
+  MOOSE is a simulation environment, not just a numerical engine.
+  It provides the essentials by way of object-oriented representations of model concepts and fast numerical solvers, but its scope is much broader.
+  It has a scripting interface with Python, graphical displays with Matplotlib, PyQt, and OpenGL, and support for many model formats.
+urls:
+  homepage: https://moose.ncbs.res.in/
+  source: https://github.com/BhallaLab/moose
+  documentation: https://moose.ncbs.res.in/readthedocs/index.html
+relations:
+  - name: NeuroML
+    description: can import, can export to

--- a/simtools/MUSIC.yaml
+++ b/simtools/MUSIC.yaml
@@ -1,16 +1,16 @@
-- name: MUSIC (MUlti-SImulation Coordinator)
-- short_name: MUSIC
-- features: API
-- operating_system: Linux, MacOS
-- interface_language: C++
-- summary: >
-    MUSIC is an API allowing large scale neuron simulators using MPI internally to exchange data during runtime.
-    MUSIC provides mechanisms to transfer massive amounts of event information and continuous values from one parallel application to another.
-    Special care has been taken to ensure that existing simulators can be adapted to MUSIC.
-    In particular, MUSIC handles data transfer between applications that use different time steps and different data allocation strategies.
-- urls:
-    homepage: https://github.com/INCF/MUSIC
-    source: https://github.com/INCF/MUSIC
-- relations:
-    - name: NEST
-      description: is used by
+name: MUSIC (MUlti-SImulation Coordinator)
+short_name: MUSIC
+features: API
+operating_system: Linux, MacOS
+interface_language: C++
+summary: |
+  MUSIC is an API allowing large scale neuron simulators using MPI internally to exchange data during runtime.
+  MUSIC provides mechanisms to transfer massive amounts of event information and continuous values from one parallel application to another.
+  Special care has been taken to ensure that existing simulators can be adapted to MUSIC.
+  In particular, MUSIC handles data transfer between applications that use different time steps and different data allocation strategies.
+urls:
+  homepage: https://github.com/INCF/MUSIC
+  source: https://github.com/INCF/MUSIC
+relations:
+  - name: NEST
+    description: is used by

--- a/simtools/NEST-Desktop.yaml
+++ b/simtools/NEST-Desktop.yaml
@@ -1,15 +1,15 @@
-- name: NEST Desktop
-- features: frontend
-- operating_system: Linux, MacOS, Windows
-- interface_language: GUI
-- summary: >
-    NEST Desktop is a web-based GUI application for NEST Simulator, an advanced simulation tool for computational neuroscience.
-    NEST Desktop enables to construct a neuronal network model graphically and to perform a simulation experiment.
-    Thus, no programming skills are required.
-- urls:
-    homepage: https://nest-desktop.readthedocs.io
-    documentation: https://nest-desktop.readthedocs.io
-    source: https://github.com/nest-desktop/nest-desktop
-- relations:
-    - name: NEST
-      description: is GUI for
+name: NEST Desktop
+features: frontend
+operating_system: Linux, MacOS, Windows
+interface_language: GUI
+summary: |
+  NEST Desktop is a web-based GUI application for NEST Simulator, an advanced simulation tool for computational neuroscience.
+  NEST Desktop enables to construct a neuronal network model graphically and to perform a simulation experiment.
+  Thus, no programming skills are required.
+urls:
+  homepage: https://nest-desktop.readthedocs.io
+  documentation: https://nest-desktop.readthedocs.io
+  source: https://github.com/nest-desktop/nest-desktop
+relations:
+  - name: NEST
+    description: is GUI for

--- a/simtools/NEST-GPU.yaml
+++ b/simtools/NEST-GPU.yaml
@@ -1,21 +1,19 @@
-- name: NEST GPU
-- features: frontend, simulator
-- operating_system: Linux
-- biological_level: Population Model, Single-Compartment (Simple) Model
-- processing_support: GPU
-- interface_language: Python, C++, C
-- summary: >
-    NEST GPU is a GPU-MPI library for simulation of large-scale networks of spiking neurons.
-
-    With this library it is possible to run relatively fast simulations of large-scale networks of spiking neurons employing GPUs. For instance, on a single NVIDIA GeForce RTX 2080 Ti GPU board it is possible to simulate the activity of 1 million multisynapse AdEx neurons with 1000 synapse per neuron in little more than 70 seconds per second of neural activity using the fifth-order Runge-Kutta method with adaptive stepsize as differential equations solver. The MPI communication is also very efficient. The Python interface is very similar to that of the NEST simulator: the most used commands are practically identical, dictionaries are used to define neurons, connections and synapsis properties in the same way.
-
-- urls:
-    homepage: https://nest-gpu.readthedocs.io
-    documentation: https://nest-gpu.readthedocs.io
-    installation: https://nest-gpu.readthedocs.io/en/latest/installation/index.html
-    examples: https://nest-gpu.readthedocs.io/en/latest/examples/index.html
-    source: https://github.com/nest/nest-gpu
-    issue tracker: https://github.com/nest/nest-gpu/issues
-- relations:
-    - name: NEST
-      description: has similar interface to # https://nest-gpu.readthedocs.io/en/latest/guides/differences_nest-gpu_nest.html
+name: NEST GPU
+features: frontend, simulator
+operating_system: Linux
+biological_level: Population Model, Single-Compartment (Simple) Model
+processing_support: GPU
+interface_language: Python, C++, C
+summary: |
+  NEST GPU is a GPU-MPI library for simulation of large-scale networks of spiking neurons.
+  With this library it is possible to run relatively fast simulations of large-scale networks of spiking neurons employing GPUs. For instance, on a single NVIDIA GeForce RTX 2080 Ti GPU board it is possible to simulate the activity of 1 million multisynapse AdEx neurons with 1000 synapse per neuron in little more than 70 seconds per second of neural activity using the fifth-order Runge-Kutta method with adaptive stepsize as differential equations solver. The MPI communication is also very efficient. The Python interface is very similar to that of the NEST simulator: the most used commands are practically identical, dictionaries are used to define neurons, connections and synapsis properties in the same way.
+urls:
+  homepage: https://nest-gpu.readthedocs.io
+  documentation: https://nest-gpu.readthedocs.io
+  installation: https://nest-gpu.readthedocs.io/en/latest/installation/index.html
+  examples: https://nest-gpu.readthedocs.io/en/latest/examples/index.html
+  source: https://github.com/nest/nest-gpu
+  issue tracker: https://github.com/nest/nest-gpu/issues
+relations:
+  - name: NEST
+    description: has similar interface to # https://nest-gpu.readthedocs.io/en/latest/guides/differences_nest-gpu_nest.html

--- a/simtools/NEST.yaml
+++ b/simtools/NEST.yaml
@@ -1,20 +1,20 @@
-- name: NEST
-- features: frontend, simulator
-- operating_system: Linux, MacOS, Windows #TODO: Python interface can be used in Windows, not the rest
-- biological_level: Population Model, Single-Compartment (Simple) Model,
-- processing_support: Single Machine, Cluster, Supercomputer
-- interface_language: Python, CLI, C++
-- summary: >
-    NEST is a simulator for spiking neural network models that focuses on the dynamics, size and structure of neural systems rather than on the exact morphology of individual neurons.
-- urls:
-    homepage: https://nest-simulator.org
-    source: https://github.com/nest/nest-simulator
-    installation: https://nest-simulator.readthedocs.io/en/stable/installation/index.html
-    documentation: https://nest-simulator.org/documentation
-    tutorial: https://nest-simulator.readthedocs.io/en/stable/tutorials/index.html#tutorials
-    examples: https://nest-simulator.readthedocs.io/en/stable/examples/index.html#pynest-examples
-    issue tracker: https://nest-simulator.readthedocs.io/en/stable/developer_space/index.html#contribute
-    forum: https://nest-simulator.readthedocs.io/en/stable/developer_space/guidelines/mailing_list_guidelines.html#mail-guidelines
-- relations:
-    - name: SONATA
-      description: can import
+name: NEST
+features: frontend, simulator
+operating_system: Linux, MacOS, Windows #TODO: Python interface can be used in Windows, not the rest
+biological_level: Population Model, Single-Compartment (Simple) Model,
+processing_support: Single Machine, Cluster, Supercomputer
+interface_language: Python, CLI, C++
+summary: |
+  NEST is a simulator for spiking neural network models that focuses on the dynamics, size and structure of neural systems rather than on the exact morphology of individual neurons.
+urls:
+  homepage: https://nest-simulator.org
+  source: https://github.com/nest/nest-simulator
+  installation: https://nest-simulator.readthedocs.io/en/stable/installation/index.html
+  documentation: https://nest-simulator.org/documentation
+  tutorial: https://nest-simulator.readthedocs.io/en/stable/tutorials/index.html#tutorials
+  examples: https://nest-simulator.readthedocs.io/en/stable/examples/index.html#pynest-examples
+  issue tracker: https://nest-simulator.readthedocs.io/en/stable/developer_space/index.html#contribute
+  forum: https://nest-simulator.readthedocs.io/en/stable/developer_space/guidelines/mailing_list_guidelines.html#mail-guidelines
+relations:
+  - name: SONATA
+    description: can import

--- a/simtools/NESTML.yaml
+++ b/simtools/NESTML.yaml
@@ -1,18 +1,18 @@
-- name: NESTML
-- features: standard
-- operating_system: Linux, MacOS, Windows
-- interface_language: Python
-- summary: >
-    NESTML is a domain-specific language for neuron and synapse models. These dynamical models can be used in simulations of brain activity on several platforms, in particular the NEST Simulator. NESTML combines an easy to understand, yet powerful syntax; a flexible processing toolchain, written in Python; and good simulation performance by means of code generation (C++ for NEST Simulator).
-- urls:
-    homepage: https://nestml.readthedocs.org/
-    source: https://github.com/nest/nestml/
-    installation: https://nestml.readthedocs.io/en/latest/installation.html
-    documentation: https://nestml.readthedocs.io/
-    tutorial: https://nestml.readthedocs.io/en/latest/tutorials/index.html
-    examples: https://github.com/nest/nestml/tree/master/models
-    issue tracker: https://github.com/nest/nestml/issues
-    forum: https://nest-simulator.readthedocs.io/en/stable/developer_space/guidelines/mailing_list_guidelines.html#mail-guidelines
-- relations:
-    - name: NEST
-      description: simulates with
+name: NESTML
+features: standard
+operating_system: Linux, MacOS, Windows
+interface_language: Python
+summary: |
+  NESTML is a domain-specific language for neuron and synapse models. These dynamical models can be used in simulations of brain activity on several platforms, in particular the NEST Simulator. NESTML combines an easy to understand, yet powerful syntax; a flexible processing toolchain, written in Python; and good simulation performance by means of code generation (C++ for NEST Simulator).
+urls:
+  homepage: https://nestml.readthedocs.org/
+  source: https://github.com/nest/nestml/
+  installation: https://nestml.readthedocs.io/en/latest/installation.html
+  documentation: https://nestml.readthedocs.io/
+  tutorial: https://nestml.readthedocs.io/en/latest/tutorials/index.html
+  examples: https://github.com/nest/nestml/tree/master/models
+  issue tracker: https://github.com/nest/nestml/issues
+  forum: https://nest-simulator.readthedocs.io/en/stable/developer_space/guidelines/mailing_list_guidelines.html#mail-guidelines
+relations:
+  - name: NEST
+    description: simulates with

--- a/simtools/NetPyNE.yaml
+++ b/simtools/NetPyNE.yaml
@@ -1,19 +1,19 @@
-- name: NetPyNE
-- features: frontend
-- operating_system: Linux, MacOS, Windows
-- interface_language: Python, GUI
-- model_description_language: NeuroML/LEMS
-- summary: >
-    NetPyNE is an open-source Python package to facilitate the development, parallel simulation, analysis, and optimization of biological neuronal networks using the NEURON simulator.
-- urls:
-    homepage: http://www.netpyne.org/
-    installation: http://www.netpyne.org/install.html
-    tutorial: http://www.netpyne.org/tutorial.html
-    source: https://github.com/suny-downstate-medical-center/netpyne
-    issue tracker: https://github.com/suny-downstate-medical-center/netpyne/issues
-    documentation: http://www.netpyne.org/user_documentation.html
-- relations:
-    - name: Neuron
-      description: simulates with
-    - name: NeuroML
-      description: imports from
+name: NetPyNE
+features: frontend
+operating_system: Linux, MacOS, Windows
+interface_language: Python, GUI
+model_description_language: NeuroML/LEMS
+summary: |
+  NetPyNE is an open-source Python package to facilitate the development, parallel simulation, analysis, and optimization of biological neuronal networks using the NEURON simulator.
+urls:
+  homepage: http://www.netpyne.org/
+  installation: http://www.netpyne.org/install.html
+  tutorial: http://www.netpyne.org/tutorial.html
+  source: https://github.com/suny-downstate-medical-center/netpyne
+  issue tracker: https://github.com/suny-downstate-medical-center/netpyne/issues
+  documentation: http://www.netpyne.org/user_documentation.html
+relations:
+  - name: Neuron
+    description: simulates with
+  - name: NeuroML
+    description: imports from

--- a/simtools/NeuroML.yaml
+++ b/simtools/NeuroML.yaml
@@ -1,46 +1,42 @@
-- name: NeuroML
-- features: standard
-- operating_system: Linux, MacOS, Windows
-- interface_language: Python, XML, GUI
-- model_description_language: NeuroML/LEMS
-- summary: >
-    NeuroML is an international, collaborative initiative to develop a language for describing detailed models of neural systems, which will serve as a standard data format for defining and exchanging descriptions of neuronal cell and network models. NeuroML is:
+name: NeuroML
+features: standard
+operating_system: Linux, MacOS, Windows
+interface_language: Python, XML, GUI
+model_description_language: NeuroML/LEMS
+summary: |
+  NeuroML is an international, collaborative initiative to develop a language for describing detailed models of neural systems, which will serve as a standard data format for defining and exchanging descriptions of neuronal cell and network models. NeuroML is:
 
+    - modular
+    - standardised
+    - structured
 
-      - modular
-      - standardised
-      - structured
+  and this allows you to:
 
+    - easily build and optimise detailed models of neural systems
+    - easily validate your models
+    - easily visualise your models
+    - easily simulate your models using a variety of simulators
+    - easily analyse your simulations
 
-    and this allows you to:
-
-
-      - easily build and optimise detailed models of neural systems
-      - easily validate your models
-      - easily visualise your models
-      - easily simulate your models using a variety of simulators
-      - easily analyse your simulations
-
-
-    all using a well supported set of tools in the powerful Python programming language.
-- urls:
-    homepage: https://neuroml.org
-    documentation: https://docs.neuroml.org
-    tutorial: https://docs.neuroml.org/Userdocs/GettingStarted.html
-    source: https://github.com/NeuroML
-    download: https://docs.neuroml.org/Userdocs/Software/Software.html
-- relations:
-    - name: Neuron
-      description: exports to, imports from, can be imported by
-    - name: NetPyNE
-      description: exports to, can be imported by
-    - name: c302
-      description: is used by
-    - name: EDEN
-      description: can be simulated by
-    - name: Brian
-      description: exports to
-    - name: PyNN
-      description: interoperates with
-    - name: Arbor
-      description: exports to, imports from, can be imported by
+  all using a well supported set of tools in the powerful Python programming language.
+urls:
+  homepage: https://neuroml.org
+  documentation: https://docs.neuroml.org
+  tutorial: https://docs.neuroml.org/Userdocs/GettingStarted.html
+  source: https://github.com/NeuroML
+  download: https://docs.neuroml.org/Userdocs/Software/Software.html
+relations:
+  - name: Neuron
+    description: exports to, imports from, can be imported by
+  - name: NetPyNE
+    description: exports to, can be imported by
+  - name: c302
+    description: is used by
+  - name: EDEN
+    description: can be simulated by
+  - name: Brian
+    description: exports to
+  - name: PyNN
+    description: interoperates with
+  - name: Arbor
+    description: exports to, imports from, can be imported by

--- a/simtools/NeuroRD.yaml
+++ b/simtools/NeuroRD.yaml
@@ -1,13 +1,13 @@
-- name: NeuroRD
-- features: frontend, simulator
-- operating_system: Linux, MacOS, Windows
-- biological_level: Single-Compartment (Complex) Model, Multi-Compartment Model
-- processing_support: Single Machine
-- interface_language: Java, CLI
-- summary: >
-    NeuroRD is a computationally efficient, stochastic reaction-diffusion simulator (pronounced NeurRDS) used mostly for simulating neuronal signaling pathways.
-    This is a Java program which runs on any platform.
-    The algorithm is based on Gillespie's tau-leap reaction algorithm, and the stochastic diffusion algorithm of Blackwell.
-    It uses XML-based model specifications.
-- urls:
-      homepage: https://krasnow1.gmu.edu/CENlab/software.html
+name: NeuroRD
+features: frontend, simulator
+operating_system: Linux, MacOS, Windows
+biological_level: Single-Compartment (Complex) Model, Multi-Compartment Model
+processing_support: Single Machine
+interface_language: Java, CLI
+summary: |
+  NeuroRD is a computationally efficient, stochastic reaction-diffusion simulator (pronounced NeurRDS) used mostly for simulating neuronal signaling pathways.
+  This is a Java program which runs on any platform.
+  The algorithm is based on Gillespie's tau-leap reaction algorithm, and the stochastic diffusion algorithm of Blackwell.
+  It uses XML-based model specifications.
+urls:
+    homepage: https://krasnow1.gmu.edu/CENlab/software.html

--- a/simtools/Neuron.yaml
+++ b/simtools/Neuron.yaml
@@ -1,24 +1,24 @@
-- name: Neuron
-- features: frontend, simulator
-- operating_system: Linux, MacOS, Windows
-- biological_level: Single-Compartment (Simple) Model, Single-Compartment (Complex) Model, Multi-Compartment Model
-- processing_support: Single Machine, Cluster, Supercomputer
-- interface_language: Python, HOC, C, C++
-- model_description_language: NMODL, HOC
-- summary: >
-    NEURON is a simulator for neurons and networks of neurons that runs efficiently on your local machine, in the cloud, or on an HPC.
-    Build and simulate models using Python, HOC, and/or NEURON's graphical interface.
-- urls:
-    homepage: https://neuron.yale.edu/neuron/
-    installation: https://nrn.readthedocs.io/en/latest/install/install.html
-    source: https://github.com/neuronsimulator/nrn
-    documentation: http://nrn.readthedocs.io/
-    download: https://nrn.readthedocs.io/en/8.2.2/#installation
-    forum: https://www.neuron.yale.edu/phpBB/
-- relations:
-    - name: NeuroML
-      description: is used by, exports to
-    - name: NetPyNE
-      description: is used by
-    - name: LFPy
-      description: is used by
+name: Neuron
+features: frontend, simulator
+operating_system: Linux, MacOS, Windows
+biological_level: Single-Compartment (Simple) Model, Single-Compartment (Complex) Model, Multi-Compartment Model
+processing_support: Single Machine, Cluster, Supercomputer
+interface_language: Python, HOC, C, C++
+model_description_language: NMODL, HOC
+summary: |
+  NEURON is a simulator for neurons and networks of neurons that runs efficiently on your local machine, in the cloud, or on an HPC.
+  Build and simulate models using Python, HOC, and/or NEURON's graphical interface.
+urls:
+  homepage: https://neuron.yale.edu/neuron/
+  installation: https://nrn.readthedocs.io/en/latest/install/install.html
+  source: https://github.com/neuronsimulator/nrn
+  documentation: http://nrn.readthedocs.io/
+  download: https://nrn.readthedocs.io/en/8.2.2/#installation
+  forum: https://www.neuron.yale.edu/phpBB/
+relations:
+  - name: NeuroML
+    description: is used by, exports to
+  - name: NetPyNE
+    description: is used by
+  - name: LFPy
+    description: is used by

--- a/simtools/NeuronC.yaml
+++ b/simtools/NeuronC.yaml
@@ -1,11 +1,11 @@
-- name: NeuronC
-- features: frontend, simulator
-- operating_system: Linux, MacOS
-- biological_level: Single-Compartment (Simple) Model, Single-Compartment (Complex) Model, Multi-Compartment Model
-- processing_support: Single Machine
-- interface_language: C
-- model_description_language: NeuronC Language
-- summary: >
-    A neural circuit simulation language that allows a user to construct a realistic biophysically-based model of a neural circuit (1 to 10,000 neurons) and simulate a physiology experiment on it.
-- urls:
-      homepage: http://retina.anatomy.upenn.edu/~rob/neuronc.html
+name: NeuronC
+features: frontend, simulator
+operating_system: Linux, MacOS
+biological_level: Single-Compartment (Simple) Model, Single-Compartment (Complex) Model, Multi-Compartment Model
+processing_support: Single Machine
+interface_language: C
+model_description_language: NeuronC Language
+summary: |
+  A neural circuit simulation language that allows a user to construct a realistic biophysically-based model of a neural circuit (1 to 10,000 neurons) and simulate a physiology experiment on it.
+urls:
+    homepage: http://retina.anatomy.upenn.edu/~rob/neuronc.html

--- a/simtools/PyNN.yaml
+++ b/simtools/PyNN.yaml
@@ -1,36 +1,33 @@
-- name: PyNN
-- features: frontend, standard
-- operating_system: Linux, MacOS, Windows
-- interface_language: Python
-- model_description_language: PyNN
-- summary: >
-    PyNN (pronounced 'pine') is a simulator-independent language for building neuronal network models.
+name: PyNN
+features: frontend, standard
+operating_system: Linux, MacOS, Windows
+interface_language: Python
+model_description_language: PyNN
+summary: |
+  PyNN (pronounced 'pine') is a simulator-independent language for building neuronal network models.
 
+  In other words, you can write the code for a model once, using the PyNN API and the Python programming language, and then run it without modification on any simulator that PyNN supports (currently NEURON, NEST and Brian 2) and on a number of neuromorphic hardware systems.
 
-    In other words, you can write the code for a model once, using the PyNN API and the Python programming language, and then run it without modification on any simulator that PyNN supports (currently NEURON, NEST and Brian 2) and on a number of neuromorphic hardware systems.
+  The PyNN API aims to support modelling at a high-level of abstraction (populations of neurons, layers, columns and the connections between them) while still allowing access to the details of individual neurons and synapses when required.
+  PyNN provides a library of standard neuron, synapse and synaptic plasticity models, which have been verified to work the same on the different supported simulators.
+  PyNN also provides a set of commonly-used connectivity algorithms (e.g. all-to-all, random, distance-dependent, small-world) but makes it easy to provide your own connectivity in a simulator-independent way.
 
-
-    The PyNN API aims to support modelling at a high-level of abstraction (populations of neurons, layers, columns and the connections between them) while still allowing access to the details of individual neurons and synapses when required.
-    PyNN provides a library of standard neuron, synapse and synaptic plasticity models, which have been verified to work the same on the different supported simulators.
-    PyNN also provides a set of commonly-used connectivity algorithms (e.g. all-to-all, random, distance-dependent, small-world) but makes it easy to provide your own connectivity in a simulator-independent way.
-
-
-    Even if you don't wish to run simulations on multiple simulators, you may benefit from writing your simulation code using PyNN's powerful, high-level interface.
-    In this case, you can use any neuron or synapse model supported by your simulator, and are not restricted to the standard models.
-- urls:
-    homepage: http://neuralensemble.org/PyNN/
-    source: https://github.com/NeuralEnsemble/PyNN/
-    documentation: http://neuralensemble.org/docs/PyNN/
-    installation: http://neuralensemble.org/docs/PyNN/installation.html
-    examples: http://neuralensemble.org/docs/PyNN/examples.html
-    forum: https://groups.google.com/forum/#!forum/neuralensemble
-    issue tracker: https://github.com/NeuralEnsemble/PyNN/issues
-- relations:
-    - name: Neuron
-      description: simulates with
-    - name: NEST
-      description: simulates with
-    - name: Brian
-      description: simulates with
-    - name: NeuroML
-      description: interoperates with
+  Even if you don't wish to run simulations on multiple simulators, you may benefit from writing your simulation code using PyNN's powerful, high-level interface.
+  In this case, you can use any neuron or synapse model supported by your simulator, and are not restricted to the standard models.
+urls:
+  homepage: http://neuralensemble.org/PyNN/
+  source: https://github.com/NeuralEnsemble/PyNN/
+  documentation: http://neuralensemble.org/docs/PyNN/
+  installation: http://neuralensemble.org/docs/PyNN/installation.html
+  examples: http://neuralensemble.org/docs/PyNN/examples.html
+  forum: https://groups.google.com/forum/#!forum/neuralensemble
+  issue tracker: https://github.com/NeuralEnsemble/PyNN/issues
+relations:
+  - name: Neuron
+    description: simulates with
+  - name: NEST
+    description: simulates with
+  - name: Brian
+    description: simulates with
+  - name: NeuroML
+    description: interoperates with

--- a/simtools/PyNeuroML.yaml
+++ b/simtools/PyNeuroML.yaml
@@ -1,27 +1,26 @@
-- name: PyNeuroML
-- features: tool
-- operating_system: Linux, MacOS, Windows
-- interface_language: Python, GUI
-- model_description_language: NeuroML/LEMS
-- summary: >
-    A single package in Python unifying scripts and modules for reading, writing, simulating and analysing NeuroML2/LEMS models.
-
-- urls:
-    homepage: https://neuroml.org
-    documentation: https://docs.neuroml.org
-    tutorial: https://docs.neuroml.org/Userdocs/GettingStarted.html
-    source: https://github.com/NeuroML/pyNeuroML
-    download: https://docs.neuroml.org/Userdocs/Software/pyNeuroML.html
-- relations:
-    - name: NeuroML
-      description: is Python package for
-    - name: libNeuroML
-      description: uses
-    - name: Neuron
-      description: simulates with
-    - name: NetPyNE
-      description: simulates with
-    - name: EDEN
-      description: simulates with
-    - name: Brian
-      description: simulates with
+name: PyNeuroML
+features: tool
+operating_system: Linux, MacOS, Windows
+interface_language: Python, GUI
+model_description_language: NeuroML/LEMS
+summary: |
+  A single package in Python unifying scripts and modules for reading, writing, simulating and analysing NeuroML2/LEMS models.
+urls:
+  homepage: https://neuroml.org
+  documentation: https://docs.neuroml.org
+  tutorial: https://docs.neuroml.org/Userdocs/GettingStarted.html
+  source: https://github.com/NeuroML/pyNeuroML
+  download: https://docs.neuroml.org/Userdocs/Software/pyNeuroML.html
+relations:
+  - name: NeuroML
+    description: is Python package for
+  - name: libNeuroML
+    description: uses
+  - name: Neuron
+    description: simulates with
+  - name: NetPyNE
+    description: simulates with
+  - name: EDEN
+    description: simulates with
+  - name: Brian
+    description: simulates with

--- a/simtools/README.md
+++ b/simtools/README.md
@@ -3,28 +3,28 @@ ignored. (It is a file with information that was gathered previously and is now
 replaced by the  individual files. As soon as all the information is
 transferred, the file will be deleted.)
 
-The file for each simulator should have a name that is the same as the name of
-the simulator, avoiding spaces. Each file is a `YAML` file with the following
+The file for each simulator should have a name that is the same as the (short) name
+of the simulator, replacing spaces with hyphens. Each file is a `YAML` file with the following
 structure (additional fields not mentioned below will be ignored; the values
-shown below are obviously example values):
+shown below are obviously example values) – the file shown here should be named `Simulator-Name.yaml`:
 
 ```yaml
-- name: Simulator Name
-- features: frontend, simulator
-- operating_system: Linux, MacOS
-- biological_level: Population Model, Single-Compartment (Simple) Model, Single-Compartment (Complex) Model, Multi-Compartment Model
-- processing_support: Single Machine, Cluster, Supercomputer, GPU
-- interface_language: Python
-- model_description_language: NeuroML/LEMS
-- summary: This simulator is very good.
-- urls:
-    homepage: https://example.com
-    email: contact@example.com
-- relations:
-      - name: Another simulator
-        description: exports to
-      - name: Yet another simulator
-        description: imports from
+name: Simulator Name
+features: frontend, simulator
+operating_system: Linux, MacOS
+biological_level: Population Model, Single-Compartment (Simple) Model, Single-Compartment (Complex) Model, Multi-Compartment Model
+processing_support: Single Machine, Cluster, Supercomputer, GPU
+interface_language: Python
+model_description_language: NeuroML/LEMS
+summary: This simulator is very good.
+urls:
+  homepage: https://example.com
+  email: contact@example.com
+relations:
+    - name: Another simulator
+      description: exports to
+    - name: Yet another simulator
+      description: imports from
 ```
 The fields `features`, `operating_system`, `biological_level`,
 `processing_support`, `interface_language`, and `model_description_language`
@@ -33,14 +33,13 @@ are comma-separated strings (i.e. not yaml lists).
 The `features` fields should contain one or more of the following values: `frontend` (for
 interfaces to simulation engines), `simulator` (for simulation engines), `standard`
 (for interoperability standards, APIs, etc.), or `tool` (for a general tool).
-Only tools that are simulators should contain the `biological_level` and
-`processing_support` fields.
+Only tools that are simulators should contain the `biological_level` field.
 
 The `urls` field contains entries that will be displayed as button labels. The
-following names are recognized: `documentation`, `installation`, `tutorial`,
+following names are recognized: `homepage`, `documentation`, `installation`, `tutorial`,
 `examples`, `email`, `chat`, `forum`, `issue tracker`, `source`, `download`.
 The `email` field  should refer to  an email address (which will be converted
-into a `mailto:` link), all other  fields should give a full URL.
+into a `mailto:` link), all other fields should give a full URL.
 
 Relations are a relationships between tools. The mentioned `name` needs to
 match the `name` of another simulator in the directory. The `description` of

--- a/simtools/ReMoto.yaml
+++ b/simtools/ReMoto.yaml
@@ -1,15 +1,15 @@
-- name: ReMoto
-- features: frontend, simulator
-- operating_system: Linux, MacOS, Windows
-- biological_level: Population Model #TODO
-- processing_support: Single Machine
-- interface_language: Web
-- summary: >
-    ReMoto was originally developed as a web-based neuronal simulation system, intended for studying spinal cord neuronal networks responsible for muscle control.
-    The simulated networks are affected by descending drive, afferent drive, and electrical nerve stimulation.
-    The simulator may be used to investigate phenomena at several levels of organization, e.g., at the neuronal membrane level or at the whole muscle behavior level (e.g., muscle force generation).
-    This versatility arises because each element (neurons, synapses, muscle fibers) has its own specific mathematical model, usually involving the action of voltage- or neurotransmitter-dependent ionic channels.
-    The simulator should be helpful in activities such as interpretation of results obtained from neurophysiological experiments in humans or mammals, proposal of hypothesis or testing models or theories on neuronal dynamics or neuronal network processing, validation of experimental protocols, and teaching neurophysiology.
-- urls:
-      homepage: http://remoto.leb.usp.br
-      tutorial: http://remoto.leb.usp.br/remoto/Learning/learning.html
+name: ReMoto
+features: frontend, simulator
+operating_system: Linux, MacOS, Windows
+biological_level: Population Model #TODO
+processing_support: Single Machine
+interface_language: Web
+summary: |
+  ReMoto was originally developed as a web-based neuronal simulation system, intended for studying spinal cord neuronal networks responsible for muscle control.
+  The simulated networks are affected by descending drive, afferent drive, and electrical nerve stimulation.
+  The simulator may be used to investigate phenomena at several levels of organization, e.g., at the neuronal membrane level or at the whole muscle behavior level (e.g., muscle force generation).
+  This versatility arises because each element (neurons, synapses, muscle fibers) has its own specific mathematical model, usually involving the action of voltage- or neurotransmitter-dependent ionic channels.
+  The simulator should be helpful in activities such as interpretation of results obtained from neurophysiological experiments in humans or mammals, proposal of hypothesis or testing models or theories on neuronal dynamics or neuronal network processing, validation of experimental protocols, and teaching neurophysiology.
+urls:
+    homepage: http://remoto.leb.usp.br
+    tutorial: http://remoto.leb.usp.br/remoto/Learning/learning.html

--- a/simtools/SNNAP.yaml
+++ b/simtools/SNNAP.yaml
@@ -1,25 +1,21 @@
-- name: SNNAP
-- features: frontend, simulator
-- operating_system: Linux, MacOS, Windows
-- biological_level: Population Model, Single-Compartment (Simple) Model, Single-Compartment (Complex) Model, Multi-Compartment Model
-- processing_support: Single Machine
-- interface_language: Java, GUI
-- summary: >
-    Simulator for Neural Networks and Action Potentials (SNNAP) is a tool for rapid development and simulation of realistic models of single neurons and neural networks.
-    It includes mathematical descriptions of ion currents and intracellular second messengers and ions.
-    In addition, you can simulate current flow in multicompartment models of neurons by using the equations describing electric coupling.
+name: SNNAP
+features: frontend, simulator
+operating_system: Linux, MacOS, Windows
+biological_level: Population Model, Single-Compartment (Simple) Model, Single-Compartment (Complex) Model, Multi-Compartment Model
+processing_support: Single Machine
+interface_language: Java, GUI
+summary: |
+  Simulator for Neural Networks and Action Potentials (SNNAP) is a tool for rapid development and simulation of realistic models of single neurons and neural networks.
+  It includes mathematical descriptions of ion currents and intracellular second messengers and ions.
+  In addition, you can simulate current flow in multicompartment models of neurons by using the equations describing electric coupling.
 
+  SNNAP also includes mathematical descriptions of intracellular second messengers and ions, and simulate the modulation of membrane currents and synaptic transmission, either enhancement or inhibition.
+  Other advantages of SNNAP include:
 
-    SNNAP also includes mathematical descriptions of intracellular second messengers and ions, and simulate the modulation of membrane currents and synaptic transmission, either enhancement or inhibition.
-
-
-    Other advantages of SNNAP include:
-
-
-      - Written in JAVA and can run on virtually any type of computer system.
-      - Graphical user interface
-      - Ability to simulate common experimental manipulations.
-      - Modular organizations of input files.
-- urls:
-      homepage: https://med.uth.edu/nba/snnap/
-      tutorial: https://med.uth.edu/nba/snnap/snnap-tutorials/
+    - Written in JAVA and can run on virtually any type of computer system.
+    - Graphical user interface
+    - Ability to simulate common experimental manipulations.
+    - Modular organizations of input files.
+urls:
+    homepage: https://med.uth.edu/nba/snnap/
+    tutorial: https://med.uth.edu/nba/snnap/snnap-tutorials/

--- a/simtools/SONATA.yaml
+++ b/simtools/SONATA.yaml
@@ -1,19 +1,19 @@
-- name: SONATA
-- features: standard
-- operating_system: Linux, MacOS, Windows
-- interface_language: Python, C++
-- model_description_language: SONATA
-- summary: >
-    The SONATA Data Format is a Scalable Open Data Format for multiscale neuronal network models and simulation output, jointly developed by the Allen Institute for Brain Science (AIBS) and the Blue Brain Project (BBP) of the École polytechnique fédérale de Lausanne (EPFL).
-    The SONATA Data Format provides:
+name: SONATA
+features: standard
+operating_system: Linux, MacOS, Windows
+interface_language: Python, C++
+model_description_language: SONATA
+summary: |
+  The SONATA Data Format is a Scalable Open Data Format for multiscale neuronal network models and simulation output, jointly developed by the Allen Institute for Brain Science (AIBS) and the Blue Brain Project (BBP) of the École polytechnique fédérale de Lausanne (EPFL).
 
-    - Facilities for representing nodes (cells) and edges (synapses/junctions) of a network. It uses table-based data structures, hdf5 and csv, to represent nodes, edges and their respective properties. Furthermore indexing procedures are specified to enable fast, parallelizable, and efficient partial lookup of individual nodes and edges. The use of hdf5 provides efficiency both in file size and IO time. , The format includes specific properties and naming conventions, but also allows modelers to extend node and edge model properties as they desire, to ensure models can be used with a variety of simulation frameworks and use cases.
-    - A JSON-based file format for configuring simulations, including specifying variables to record from, and stimuli to apply.
-    - A systematic schema for describing simulation output/reports making it easy for users to exchange their simulation output data, and moreover the underlying hdf5 based format permits efficient storage of variables such as spike times, membrane potential, and Ca2+ concentration.
+  The SONATA Data Format provides:
 
-- urls:
-    homepage: https://github.com/BlueBrain/sonata
-    source: https://github.com/BlueBrain/sonata
-- relations:
-  - name: NeuroML
-    description: interoperates with
+  - Facilities for representing nodes (cells) and edges (synapses/junctions) of a network. It uses table-based data structures, hdf5 and csv, to represent nodes, edges and their respective properties. Furthermore indexing procedures are specified to enable fast, parallelizable, and efficient partial lookup of individual nodes and edges. The use of hdf5 provides efficiency both in file size and IO time. , The format includes specific properties and naming conventions, but also allows modelers to extend node and edge model properties as they desire, to ensure models can be used with a variety of simulation frameworks and use cases.
+  - A JSON-based file format for configuring simulations, including specifying variables to record from, and stimuli to apply.
+  - A systematic schema for describing simulation output/reports making it easy for users to exchange their simulation output data, and moreover the underlying hdf5 based format permits efficient storage of variables such as spike times, membrane potential, and Ca2+ concentration.
+urls:
+  homepage: https://github.com/BlueBrain/sonata
+  source: https://github.com/BlueBrain/sonata
+relations:
+- name: NeuroML
+  description: interoperates with

--- a/simtools/Steps.yaml
+++ b/simtools/Steps.yaml
@@ -1,24 +1,21 @@
-- name: Steps
-- features: frontend, simulator
-- operating_system: Linux, MacOS, Windows
-- biological_level: Single-Compartment (Simple) Model, Single-Compartment (Complex) Model, Multi-Compartment Model #TODO
-- processing_support: Single Machine, GPU
-- interface_language: Python, C, C++
-- summary: >
-    STEPS is a package for exact stochastic simulation of reaction-diffusion systems in arbitrarily complex 3D geometries.
-    Our core simulation algorithm is an implementation of Gillespie's SSA, extended to deal with diffusion of molecules over the elements of a 3D tetrahedral mesh.
+name: Steps
+features: frontend, simulator
+operating_system: Linux, MacOS, Windows
+biological_level: Single-Compartment (Simple) Model, Single-Compartment (Complex) Model, Multi-Compartment Model #TODO
+processing_support: Single Machine, GPU
+interface_language: Python, C, C++
+summary: |
+  STEPS is a package for exact stochastic simulation of reaction-diffusion systems in arbitrarily complex 3D geometries.
+  Our core simulation algorithm is an implementation of Gillespie's SSA, extended to deal with diffusion of molecules over the elements of a 3D tetrahedral mesh.
 
+  While it was mainly developed for simulating detailed models of neuronal signaling pathways in dendrites and around synapses, it is a general tool and can be used for studying any biochemical pathway in which spatial gradients and morphology are thought to play a role.
 
-    While it was mainly developed for simulating detailed models of neuronal signaling pathways in dendrites and around synapses, it is a general tool and can be used for studying any biochemical pathway in which spatial gradients and morphology are thought to play a role.
+  STEPS also supports accurate and efficient computational of local membrane potentials on tetrahedral meshes, with the addition of voltage-gated channels and currents.
+  Tight integration between the reaction-diffusion calculations and the tetrahedral mesh potentials allows detailed coupling between molecular activity and local electrical excitability.
 
-
-    STEPS also supports accurate and efficient computational of local membrane potentials on tetrahedral meshes, with the addition of voltage-gated channels and currents.
-    Tight integration between the reaction-diffusion calculations and the tetrahedral mesh potentials allows detailed coupling between molecular activity and local electrical excitability.
-
-
-    We have implemented STEPS as a set of Python modules, which means STEPS users can use Python scripts to control all aspects of setting up the model, generating a mesh, controlling the simulation and generating and analyzing output.
-    The core computational routines are still implemented as C/C++ extension modules for maximal speed of execution.
-- urls:
-    homepage: https://steps.sourceforge.net/STEPS/default.php
-    source: https://github.com/CNS-OIST/STEPS
-    documentation: https://steps.sourceforge.net/manual/
+  We have implemented STEPS as a set of Python modules, which means STEPS users can use Python scripts to control all aspects of setting up the model, generating a mesh, controlling the simulation and generating and analyzing output.
+  The core computational routines are still implemented as C/C++ extension modules for maximal speed of execution.
+urls:
+  homepage: https://steps.sourceforge.net/STEPS/default.php
+  source: https://github.com/CNS-OIST/STEPS
+  documentation: https://steps.sourceforge.net/manual/

--- a/simtools/TVB.yaml
+++ b/simtools/TVB.yaml
@@ -1,24 +1,22 @@
-- name: TheVirtualBrain (TVB)
-- short_name: TVB
-- features: frontend, simulator
-- operating_system: Linux, MacOS, Windows
-- biological_level: Population Model
-- interface_language: Python, GUI
-- processing_support: Single Machine, Cluster, Supercomputer
-- summary: >
-    Simulating the human brain is the holy grail of neuroscience - offering a pioneering tool for understanding how our brain works and how to deal with its disorders like stroke, epilepsy or neurodegenerative diseases like Alzheimer's or Parkinson's.
+name: TheVirtualBrain (TVB)
+short_name: TVB
+features: frontend, simulator
+operating_system: Linux, MacOS, Windows
+biological_level: Population Model
+interface_language: Python, GUI
+processing_support: Single Machine, Cluster, Supercomputer
+summary: |
+  Simulating the human brain is the holy grail of neuroscience - offering a pioneering tool for understanding how our brain works and how to deal with its disorders like stroke, epilepsy or neurodegenerative diseases like Alzheimer's or Parkinson's.
 
+  While large-scale research initiatives simulate neurons and small brain regions at the cellular level on massively parallel hardware, they are still years away from clinical applications.
 
-    While large-scale research initiatives simulate neurons and small brain regions at the cellular level on massively parallel hardware, they are still years away from clinical applications.
-
-
-    The Virtual Brain (TVB) takes a different approach and reduces complexity on the micro level to attain the macro organization. A TVB model of a patient's brain generates sufficiently accurate EEG, MEG, BOLD and SEEG signals by reducing the complexity millionfold through methods from statistical physics.
-    The key is TVB’s hybrid approach of merging individual anatomy from brain imaging data with state-of-the-art mathematical modeling.
-- urls:
-    homepage: https://www.thevirtualbrain.org/
-    source: https://github.com/the-virtual-brain/
-    documentation: http://docs.thevirtualbrain.org/
-    examples: https://github.com/the-virtual-brain/tvb-documentation/tree/master/demos
-    forum: https://groups.google.com/group/tvb-users/
-    issue tracker: http://req.thevirtualbrain.org/
-    download: https://www.thevirtualbrain.org/tvb/zwei/brainsimulator-software
+  The Virtual Brain (TVB) takes a different approach and reduces complexity on the micro level to attain the macro organization. A TVB model of a patient's brain generates sufficiently accurate EEG, MEG, BOLD and SEEG signals by reducing the complexity millionfold through methods from statistical physics.
+  The key is TVB’s hybrid approach of merging individual anatomy from brain imaging data with state-of-the-art mathematical modeling.
+urls:
+  homepage: https://www.thevirtualbrain.org/
+  source: https://github.com/the-virtual-brain/
+  documentation: http://docs.thevirtualbrain.org/
+  examples: https://github.com/the-virtual-brain/tvb-documentation/tree/master/demos
+  forum: https://groups.google.com/group/tvb-users/
+  issue tracker: http://req.thevirtualbrain.org/
+  download: https://www.thevirtualbrain.org/tvb/zwei/brainsimulator-software

--- a/simtools/c302.yaml
+++ b/simtools/c302.yaml
@@ -1,13 +1,13 @@
-- name: c302
-- features: API, library
-- operating_system: Linux, MacOS, Windows
-- interface_language: Python
-- summary: >
-    c302 is a framework for generating network models in NeuroML 2 based on C. elegans connectivity data.
-    It is primarily intended as a way to generate neuronal networks at multiple levels of detail for the [OpenWorm](http://www.openworm.org/) project.
-- urls:
-    homepage: https://www.opensourcebrain.org/projects/c302
-    source: https://github.com/openworm/c302
-- relations:
-    - name: NeuroML
-      description: exports to
+name: c302
+features: API, library
+operating_system: Linux, MacOS, Windows
+interface_language: Python
+summary: |
+  c302 is a framework for generating network models in NeuroML 2 based on C. elegans connectivity data.
+  It is primarily intended as a way to generate neuronal networks at multiple levels of detail for the [OpenWorm](http://www.openworm.org/) project.
+urls:
+  homepage: https://www.opensourcebrain.org/projects/c302
+  source: https://github.com/openworm/c302
+relations:
+  - name: NeuroML
+    description: exports to

--- a/simtools/libNeuroML.yaml
+++ b/simtools/libNeuroML.yaml
@@ -1,19 +1,18 @@
-- name: libNeuroML
-- features: API
-- operating_system: Linux, MacOS, Windows
-- interface_language: Python
-- model_description_language: NeuroML/LEMS
-- summary: >
-    Python API for working with NeuroML models
-
-- urls:
-    homepage: https://neuroml.org
-    documentation: https://docs.neuroml.org
-    tutorial: https://docs.neuroml.org/Userdocs/GettingStarted.html
-    source: https://github.com/NeuralEnsemble/libNeuroML
-    download: https://docs.neuroml.org/Userdocs/Software/libNeuroML.html
-- relations:
-    - name: NeuroML
-      description: is Python API for
-    - name: PyNeuroML
-      description: is used by
+name: libNeuroML
+features: API
+operating_system: Linux, MacOS, Windows
+interface_language: Python
+model_description_language: NeuroML/LEMS
+summary: |
+  Python API for working with NeuroML models
+urls:
+  homepage: https://neuroml.org
+  documentation: https://docs.neuroml.org
+  tutorial: https://docs.neuroml.org/Userdocs/GettingStarted.html
+  source: https://github.com/NeuralEnsemble/libNeuroML
+  download: https://docs.neuroml.org/Userdocs/Software/libNeuroML.html
+relations:
+  - name: NeuroML
+    description: is Python API for
+  - name: PyNeuroML
+    description: is used by

--- a/simtools/nrn-patch.yaml
+++ b/simtools/nrn-patch.yaml
@@ -1,11 +1,11 @@
-- name: nrn-patch
-- features: frontend
-- operating_system: Windows, MacOS, Linux
-- interface_language: Python
-- summary:
-    A Pythonic object-oriented drop-in replacement for the Python interface to NEURON.
-- relations:
-    - name: Neuron
-      description: is Python API for
-- urls:
-      homepage: https://github.com/dbbs-lab/patch
+name: nrn-patch
+features: frontend
+operating_system: Windows, MacOS, Linux
+interface_language: Python
+summary:
+  A Pythonic object-oriented drop-in replacement for the Python interface to NEURON.
+relations:
+  - name: Neuron
+    description: is Python API for
+urls:
+    homepage: https://github.com/dbbs-lab/patch

--- a/simtools/simtools.json
+++ b/simtools/simtools.json
@@ -24,7 +24,7 @@
     "name": "Arbor",
     "operating_system": "Linux, MacOS, Windows",
     "processing_support": "Single Machine, Cluster, Supercomputer, GPU",
-    "summary": "<p>Arbor is a high-performance library for computational neuroscience simulations with multi-compartment, morphologically-detailed cells, from single cell models to very large networks. Arbor is written from the ground up with many-cpu and gpu architectures in mind, to help neuroscientists effectively use contemporary and future HPC systems to meet their simulation needs.</p>\n<p>Arbor supports NVIDIA and AMD GPUs as well as explicit vectorization on CPUs from Intel (AVX, AVX2 and AVX512) and ARM (Neon and SVE). When coupled with low memory overheads, this makes Arbor an order of magnitude faster than the most widely-used comparable simulation software.</p>\n<p>Arbor is open source and openly developed, and we use development practices such as unit testing, continuous integration, and validation.</p>",
+    "summary": "<p>Arbor is a high-performance library for computational neuroscience simulations with multi-compartment, morphologically-detailed cells, from single cell models to very large networks.\nArbor is written from the ground up with many-cpu and gpu architectures in mind, to help neuroscientists effectively use contemporary and future HPC systems to meet their simulation needs.</p>\n<p>Arbor supports NVIDIA and AMD GPUs as well as explicit vectorization on CPUs from Intel (AVX, AVX2 and AVX512) and ARM (Neon and SVE).\nWhen coupled with low memory overheads, this makes Arbor an order of magnitude faster than the most widely-used comparable simulation software.</p>\n<p>Arbor is open source and openly developed, and we use development practices such as unit testing, continuous integration, and validation.</p>",
     "urls": {
       "chat": "https://gitter.im/arbor-sim/community",
       "documentation": "https://docs.arbor-sim.org",
@@ -50,7 +50,7 @@
         "name": "Arbor"
       }
     ],
-    "summary": "<p>Arbor GUI is a comprehensive tool for building single cell models using Arbor. It strives to be self-contained, fast, and easy to use.</p>\n<ul>\n<li>Design morphologically detailled cells for simulation in Arbor.</li>\n<li>Load morphologies from SWC .swc, NeuroML .nml, NeuroLucida .asc.</li>\n<li>Define and highlight Arbor regions and locsets.</li>\n<li>Paint ion dynamics and bio-physical properties onto morphologies.</li>\n<li>Place spike detectors and probes.</li>\n<li>Export cable cells to Arbor\u2019s internal format (ACC) for direct simulation.</li>\n<li>Import cable cells in ACC format</li>\n</ul>",
+    "summary": "<p>Arbor GUI is a comprehensive tool for building single cell models using Arbor.\nIt strives to be self-contained, fast, and easy to use.</p>\n<ul>\n<li>Design morphologically detailled cells for simulation in Arbor.</li>\n<li>Load morphologies from SWC .swc, NeuroML .nml, NeuroLucida .asc.</li>\n<li>Define and highlight Arbor regions and locsets.</li>\n<li>Paint ion dynamics and bio-physical properties onto morphologies.</li>\n<li>Place spike detectors and probes.</li>\n<li>Export cable cells to Arbor\u2019s internal format (ACC) for direct simulation.</li>\n<li>Import cable cells in ACC format</li>\n</ul>",
     "urls": {
       "chat": "https://gitter.im/arbor-sim/gui",
       "download": "https://github.com/arbor-sim/gui/releases/",
@@ -90,7 +90,7 @@
         "name": "SONATA"
       }
     ],
-    "summary": "<p>The Brain Modeling Toolkit (BMTK) is a python-based software package for building, simulating and analyzing large-scale neural network models. It supports the building and simulation of models of varying levels-of-resolution; from multi-compartment biophysically detailed networks, to point-neuron models, to filter-based models, and even population-level firing rate models.</p>\n<p>The BMTK is not itself a simulator and will utilize existing simulators, like NEURON and NEST, to run different types of models. What BMTK does provide:</p>\n<ul>\n<li>A unified interface across different simulators, so that modelers can work with and study their own network models across different simulators without having to learn how to use each tool.</li>\n<li>An easy way to setup and initialize network simulations with little-to-no programming necessary</li>\n<li>Automatic integration of parallelization when running on HPC.</li>\n<li>Extra built-in features which the native simulators may not support out-of-the-box.</li>\n</ul>\n<p>The BMTK was developed and is supported at the Allen Institute for Brain Science and released under a BSD 3-clause license. We encourage others to use the BMTK for their own research, and suggestions and contributions to the BMTK are welcome.</p>",
+    "summary": "<p>The Brain Modeling Toolkit (BMTK) is a python-based software package for building, simulating and analyzing large-scale neural network models.\nIt supports the building and simulation of models of varying levels-of-resolution; from multi-compartment biophysically detailed networks, to point-neuron models, to filter-based models, and even population-level firing rate models.</p>\n<p>The BMTK is not itself a simulator and will utilize existing simulators, like NEURON and NEST, to run different types of models.\nWhat BMTK does provide:</p>\n<ul>\n<li>A unified interface across different simulators, so that modelers can work with and study their own network models across different simulators without having to learn how to use each tool.</li>\n<li>An easy way to setup and initialize network simulations with little-to-no programming necessary</li>\n<li>Automatic integration of parallelization when running on HPC.</li>\n<li>Extra built-in features which the native simulators may not support out-of-the-box.</li>\n</ul>\n<p>The BMTK was developed and is supported at the Allen Institute for Brain Science and released under a BSD 3-clause license.\nWe encourage others to use the BMTK for their own research, and suggestions and contributions to the BMTK are welcome.</p>",
     "urls": {
       "homepage": "https://alleninstitute.github.io/bmtk/"
     }
@@ -106,7 +106,7 @@
         "name": "NeuroML"
       }
     ],
-    "summary": "<p>The Blue Brain Python Optimisation Library (BluePyOpt) is an extensible framework for data-driven model parameter optimisation that wraps and standardises several existing open-source tools.</p>\n<p>It simplifies the task of creating and sharing these optimisations, and the associated techniques and knowledge. This is achieved by abstracting the optimisation and evaluation tasks into various reusable and flexible discrete elements according to established best-practices.</p>\n<p>Further, BluePyOpt provides methods for setting up both small- and large-scale optimisations on a variety of platforms, ranging from laptops to Linux clusters and cloud-based compute infrastructures.</p>",
+    "summary": "<p>The Blue Brain Python Optimisation Library (BluePyOpt) is an extensible framework for data-driven model parameter optimisation that wraps and standardises several existing open-source tools.</p>\n<p>It simplifies the task of creating and sharing these optimisations, and the associated techniques and knowledge.\nThis is achieved by abstracting the optimisation and evaluation tasks into various reusable and flexible discrete elements according to established best-practices.</p>\n<p>Further, BluePyOpt provides methods for setting up both small- and large-scale optimisations on a variety of platforms, ranging from laptops to Linux clusters and cloud-based compute infrastructures.</p>",
     "urls": {
       "homepage": "https://bluepyopt.readthedocs.io"
     }
@@ -130,7 +130,7 @@
         "name": "Arbor"
       }
     ],
-    "summary": "<p>The Brain Scaffold Builder (BSB) is a black box component framework for multiparadigm neural modelling: we provide structure, architecture and organization, and you provide the use-case specific parts of your model. In our framework, your model is described in a code-free configuration of components with parameters.</p>\n<p>For the framework to reliably use components, and make them work together in a complex workflow, it asks a fixed set of questions per component type: e.g. a connection component will be asked how to connect cells. These contracts of cooperation between you and the framework are called interfaces. The framework executes a transparently parallelized workflow, and calls your components to fulfill their role.</p>\n<p>This way, by implementing our component interfaces and declaring them in a configuration file, most models end up being code-free, well-parametrized, self-contained, human-readable, multi-scale models!</p>",
+    "summary": "<p>The Brain Scaffold Builder (BSB) is a black box component framework for multiparadigm neural modelling: we provide structure, architecture and organization, and you provide the use-case specific parts of your model.\nIn our framework, your model is described in a code-free configuration of components with parameters.</p>\n<p>For the framework to reliably use components, and make them work together in a complex workflow, it asks a fixed set of questions per component type: e.g. a connection component will be asked how to connect cells.\nThese contracts of cooperation between you and the framework are called interfaces. The framework executes a transparently parallelized workflow, and calls your components to fulfill their role.</p>\n<p>This way, by implementing our component interfaces and declaring them in a configuration file, most models end up being code-free, well-parametrized, self-contained, human-readable, multi-scale models!</p>",
     "urls": {
       "homepage": "https://bsb.readthedocs.io"
     }
@@ -142,7 +142,7 @@
     "name": "Brain dynamics toolbox",
     "operating_system": "Linux, MacOS, Windows",
     "processing_support": "Single Machine",
-    "summary": "<p>The Brain Dynamics Toolbox is open-source Matlab software for simulating bespoke dynamical systems in neuroscience and beyond. Users define their system of equations as a custom matlab function. Interchangeable solvers and plotting tools can then be applied to that system with no additional programming effort.</p>",
+    "summary": "<p>The Brain Dynamics Toolbox is open-source Matlab software for simulating bespoke dynamical systems in neuroscience and beyond.\nUsers define their system of equations as a custom matlab function.\nInterchangeable solvers and plotting tools can then be applied to that system with no additional programming effort.</p>",
     "urls": {
       "homepage": "http://bdtoolbox.org/"
     }
@@ -154,7 +154,7 @@
     "name": "Brian",
     "operating_system": "Linux, MacOS, Windows",
     "processing_support": "Single Machine, Cluster",
-    "summary": "<p>Brian is a free, open source simulator for spiking neural networks. It is written in the Python programming language and is available on almost all platforms. We believe that a simulator should not only save the time of processors, but also the time of scientists. Brian is therefore designed to be easy to learn and use, highly flexible and easily extensible.</p>",
+    "summary": "<p>Brian is a free, open source simulator for spiking neural networks. It is written in the Python programming language\nand is available on almost all platforms. We believe that a simulator should not only save the time of processors,\nbut also the time of scientists. Brian is therefore designed to be easy to learn and use, highly flexible and easily\nextensible.</p>",
     "urls": {
       "chat": "https://gitter.im/brian-team/brian2",
       "documentation": "https://brian2.readthedocs.io/",
@@ -169,7 +169,6 @@
     }
   },
   "Brian2CUDA": {
-    "biological_level": "Population Model, Single-Compartment (Simple) Model, Single-Compartment (Complex) Model, Multi-Compartment Model",
     "features": "library",
     "interface_language": "Python",
     "name": "Brian2CUDA",
@@ -181,7 +180,7 @@
         "name": "Brian"
       }
     ],
-    "summary": "<p>Brian2CUDA is a Python package for simulating spiking neural networks on graphics processing units (GPUs). It is an extension of the spiking neural network simulator Brian2, which allows flexible model definitions in Python. Brian2CUDA uses the code generation system from Brian2 to generate simulation code in C++/CUDA, which is then executed on NVIDIA GPUs.</p>",
+    "summary": "<p>Brian2CUDA is a Python package for simulating spiking neural networks on graphics processing units (GPUs).\nIt is an extension of the spiking neural network simulator Brian2, which allows flexible model definitions in\nPython. Brian2CUDA uses the code generation system from Brian2 to generate simulation code in C++/CUDA, which is\nthen executed on NVIDIA GPUs.</p>",
     "urls": {
       "documentation": "https://brian2cuda.readthedocs.io",
       "download": "https://pypi.org/project/Brian2CUDA/",
@@ -205,7 +204,7 @@
         "name": "GeNN"
       }
     ],
-    "summary": "<p>Brian2GeNN connects Brian 2 to the GeNN simulator, so that users can make use of GeNN GPU acceleration when developing their models in Brian, without requiring any technical knowledge about GPUs, C++ or GeNN.</p>",
+    "summary": "<p>Brian2GeNN connects Brian 2 to the GeNN simulator, so that users can make use of GeNN GPU acceleration when\ndeveloping their models in Brian, without requiring any technical knowledge about GPUs, C++ or GeNN.</p>",
     "urls": {
       "documentation": "https://brian2genn.readthedocs.io",
       "download": "https://pypi.org/project/Brian2GeNN/",
@@ -221,7 +220,7 @@
     "name": "DiPDE",
     "operating_system": "Linux, MacOS, Windows",
     "processing_support": "Single Machine",
-    "summary": "<p>DiPDE (dipde) is a simulation platform for numerically solving the time evolution of coupled networks of neuronal populations. Instead of solving the subthreshold dynamics of individual model leaky-integrate-and-fire (LIF) neurons, dipde models the voltage distribution of a population of neurons with a single population density equation. In this way, dipde can facilitate the fast exploration of mesoscale (population-level) network topologies, where large populations of neurons are treated as homogeneous with random fine-scale connectivity.</p>",
+    "summary": "<p>DiPDE (dipde) is a simulation platform for numerically solving the time evolution of coupled networks of neuronal populations.\nInstead of solving the subthreshold dynamics of individual model leaky-integrate-and-fire (LIF) neurons, dipde models the voltage distribution of a population of neurons with a single population density equation.\nIn this way, dipde can facilitate the fast exploration of mesoscale (population-level) network topologies, where large populations of neurons are treated as homogeneous with random fine-scale connectivity.</p>",
     "urls": {
       "homepage": "https://alleninstitute.github.io/dipde/index.html"
     }
@@ -276,7 +275,7 @@
     "interface_language": "Python, Javascript",
     "name": "Geppeto",
     "operating_system": "Linux, MacOS, Windows",
-    "summary": "<p>Geppetto is a web-based visualisation and simulation platform to build neuroscience software applications. Reuse best practices, best compomnents, best design. Don't reinvent the wheel.</p>",
+    "summary": "<p>Geppetto is a web-based visualisation and simulation platform to build neuroscience software applications.\nReuse best practices, best compomnents, best design.\nDon't reinvent the wheel.</p>",
     "urls": {
       "homepage": "https://www.geppetto.org/"
     }
@@ -292,7 +291,7 @@
         "name": "Neuron"
       }
     ],
-    "summary": "<p>LFPy is a Python module for calculation of extracellular potentials from multicompartment neuron models. It relies on the NEURON simulator and uses the Python interface it provides.</p>",
+    "summary": "<p>LFPy is a Python module for calculation of extracellular potentials from multicompartment neuron models.\nIt relies on the NEURON simulator and uses the Python interface it provides.</p>",
     "urls": {
       "documentation": "https://lfpy.readthedocs.io/en/latest/",
       "download": "https://pypi.org/project/LFPy/",
@@ -313,7 +312,7 @@
         "name": "NeuroML"
       }
     ],
-    "summary": "<p>MOOSE is the Multiscale Object-Oriented Simulation Environment. It is designed to simulate neural systems ranging from subcellular components and biochemical reactions to complex models of single neurons, circuits, and large networks. MOOSE can operate at many levels of detail, from stochastic chemical computations, to multicompartment single-neuron models, to spiking neuron network models.</p>\n<p>MOOSE is a simulation environment, not just a numerical engine. It provides the essentials by way of object-oriented representations of model concepts and fast numerical solvers, but its scope is much broader. It has a scripting interface with Python, graphical displays with Matplotlib, PyQt, and OpenGL, and support for many model formats.</p>",
+    "summary": "<p>MOOSE is the Multiscale Object-Oriented Simulation Environment.\nIt is designed to simulate neural systems ranging from subcellular components and biochemical reactions to complex models of single neurons, circuits, and large networks.\nMOOSE can operate at many levels of detail, from stochastic chemical computations, to multicompartment single-neuron models, to spiking neuron network models.</p>\n<p>MOOSE is a simulation environment, not just a numerical engine.\nIt provides the essentials by way of object-oriented representations of model concepts and fast numerical solvers, but its scope is much broader.\nIt has a scripting interface with Python, graphical displays with Matplotlib, PyQt, and OpenGL, and support for many model formats.</p>",
     "urls": {
       "documentation": "https://moose.ncbs.res.in/readthedocs/index.html",
       "homepage": "https://moose.ncbs.res.in/",
@@ -331,7 +330,7 @@
         "name": "NEST"
       }
     ],
-    "summary": "<p>MUSIC is an API allowing large scale neuron simulators using MPI internally to exchange data during runtime. MUSIC provides mechanisms to transfer massive amounts of event information and continuous values from one parallel application to another. Special care has been taken to ensure that existing simulators can be adapted to MUSIC. In particular, MUSIC handles data transfer between applications that use different time steps and different data allocation strategies.</p>",
+    "summary": "<p>MUSIC is an API allowing large scale neuron simulators using MPI internally to exchange data during runtime.\nMUSIC provides mechanisms to transfer massive amounts of event information and continuous values from one parallel application to another.\nSpecial care has been taken to ensure that existing simulators can be adapted to MUSIC.\nIn particular, MUSIC handles data transfer between applications that use different time steps and different data allocation strategies.</p>",
     "urls": {
       "homepage": "https://github.com/INCF/MUSIC",
       "source": "https://github.com/INCF/MUSIC"
@@ -373,7 +372,7 @@
         "name": "NEST"
       }
     ],
-    "summary": "<p>NEST Desktop is a web-based GUI application for NEST Simulator, an advanced simulation tool for computational neuroscience. NEST Desktop enables to construct a neuronal network model graphically and to perform a simulation experiment. Thus, no programming skills are required.</p>",
+    "summary": "<p>NEST Desktop is a web-based GUI application for NEST Simulator, an advanced simulation tool for computational neuroscience.\nNEST Desktop enables to construct a neuronal network model graphically and to perform a simulation experiment.\nThus, no programming skills are required.</p>",
     "urls": {
       "documentation": "https://nest-desktop.readthedocs.io",
       "homepage": "https://nest-desktop.readthedocs.io",
@@ -504,7 +503,7 @@
     "name": "NeuroRD",
     "operating_system": "Linux, MacOS, Windows",
     "processing_support": "Single Machine",
-    "summary": "<p>NeuroRD is a computationally efficient, stochastic reaction-diffusion simulator (pronounced NeurRDS) used mostly for simulating neuronal signaling pathways. This is a Java program which runs on any platform. The algorithm is based on Gillespie's tau-leap reaction algorithm, and the stochastic diffusion algorithm of Blackwell. It uses XML-based model specifications.</p>",
+    "summary": "<p>NeuroRD is a computationally efficient, stochastic reaction-diffusion simulator (pronounced NeurRDS) used mostly for simulating neuronal signaling pathways.\nThis is a Java program which runs on any platform.\nThe algorithm is based on Gillespie's tau-leap reaction algorithm, and the stochastic diffusion algorithm of Blackwell.\nIt uses XML-based model specifications.</p>",
     "urls": {
       "homepage": "https://krasnow1.gmu.edu/CENlab/software.html"
     }
@@ -531,7 +530,7 @@
         "name": "LFPy"
       }
     ],
-    "summary": "<p>NEURON is a simulator for neurons and networks of neurons that runs efficiently on your local machine, in the cloud, or on an HPC. Build and simulate models using Python, HOC, and/or NEURON's graphical interface.</p>",
+    "summary": "<p>NEURON is a simulator for neurons and networks of neurons that runs efficiently on your local machine, in the cloud, or on an HPC.\nBuild and simulate models using Python, HOC, and/or NEURON's graphical interface.</p>",
     "urls": {
       "documentation": "http://nrn.readthedocs.io/",
       "download": "https://nrn.readthedocs.io/en/8.2.2/#installation",
@@ -578,7 +577,7 @@
         "name": "NeuroML"
       }
     ],
-    "summary": "<p>PyNN (pronounced 'pine') is a simulator-independent language for building neuronal network models.</p>\n<p>In other words, you can write the code for a model once, using the PyNN API and the Python programming language, and then run it without modification on any simulator that PyNN supports (currently NEURON, NEST and Brian 2) and on a number of neuromorphic hardware systems.</p>\n<p>The PyNN API aims to support modelling at a high-level of abstraction (populations of neurons, layers, columns and the connections between them) while still allowing access to the details of individual neurons and synapses when required. PyNN provides a library of standard neuron, synapse and synaptic plasticity models, which have been verified to work the same on the different supported simulators. PyNN also provides a set of commonly-used connectivity algorithms (e.g. all-to-all, random, distance-dependent, small-world) but makes it easy to provide your own connectivity in a simulator-independent way.</p>\n<p>Even if you don't wish to run simulations on multiple simulators, you may benefit from writing your simulation code using PyNN's powerful, high-level interface. In this case, you can use any neuron or synapse model supported by your simulator, and are not restricted to the standard models.</p>",
+    "summary": "<p>PyNN (pronounced 'pine') is a simulator-independent language for building neuronal network models.</p>\n<p>In other words, you can write the code for a model once, using the PyNN API and the Python programming language, and then run it without modification on any simulator that PyNN supports (currently NEURON, NEST and Brian 2) and on a number of neuromorphic hardware systems.</p>\n<p>The PyNN API aims to support modelling at a high-level of abstraction (populations of neurons, layers, columns and the connections between them) while still allowing access to the details of individual neurons and synapses when required.\nPyNN provides a library of standard neuron, synapse and synaptic plasticity models, which have been verified to work the same on the different supported simulators.\nPyNN also provides a set of commonly-used connectivity algorithms (e.g. all-to-all, random, distance-dependent, small-world) but makes it easy to provide your own connectivity in a simulator-independent way.</p>\n<p>Even if you don't wish to run simulations on multiple simulators, you may benefit from writing your simulation code using PyNN's powerful, high-level interface.\nIn this case, you can use any neuron or synapse model supported by your simulator, and are not restricted to the standard models.</p>",
     "urls": {
       "documentation": "http://neuralensemble.org/docs/PyNN/",
       "examples": "http://neuralensemble.org/docs/PyNN/examples.html",
@@ -637,7 +636,7 @@
     "name": "ReMoto",
     "operating_system": "Linux, MacOS, Windows",
     "processing_support": "Single Machine",
-    "summary": "<p>ReMoto was originally developed as a web-based neuronal simulation system, intended for studying spinal cord neuronal networks responsible for muscle control. The simulated networks are affected by descending drive, afferent drive, and electrical nerve stimulation. The simulator may be used to investigate phenomena at several levels of organization, e.g., at the neuronal membrane level or at the whole muscle behavior level (e.g., muscle force generation). This versatility arises because each element (neurons, synapses, muscle fibers) has its own specific mathematical model, usually involving the action of voltage- or neurotransmitter-dependent ionic channels. The simulator should be helpful in activities such as interpretation of results obtained from neurophysiological experiments in humans or mammals, proposal of hypothesis or testing models or theories on neuronal dynamics or neuronal network processing, validation of experimental protocols, and teaching neurophysiology.</p>",
+    "summary": "<p>ReMoto was originally developed as a web-based neuronal simulation system, intended for studying spinal cord neuronal networks responsible for muscle control.\nThe simulated networks are affected by descending drive, afferent drive, and electrical nerve stimulation.\nThe simulator may be used to investigate phenomena at several levels of organization, e.g., at the neuronal membrane level or at the whole muscle behavior level (e.g., muscle force generation).\nThis versatility arises because each element (neurons, synapses, muscle fibers) has its own specific mathematical model, usually involving the action of voltage- or neurotransmitter-dependent ionic channels.\nThe simulator should be helpful in activities such as interpretation of results obtained from neurophysiological experiments in humans or mammals, proposal of hypothesis or testing models or theories on neuronal dynamics or neuronal network processing, validation of experimental protocols, and teaching neurophysiology.</p>",
     "urls": {
       "homepage": "http://remoto.leb.usp.br",
       "tutorial": "http://remoto.leb.usp.br/remoto/Learning/learning.html"
@@ -650,7 +649,7 @@
     "name": "SNNAP",
     "operating_system": "Linux, MacOS, Windows",
     "processing_support": "Single Machine",
-    "summary": "<p>Simulator for Neural Networks and Action Potentials (SNNAP) is a tool for rapid development and simulation of realistic models of single neurons and neural networks. It includes mathematical descriptions of ion currents and intracellular second messengers and ions. In addition, you can simulate current flow in multicompartment models of neurons by using the equations describing electric coupling.</p>\n<p>SNNAP also includes mathematical descriptions of intracellular second messengers and ions, and simulate the modulation of membrane currents and synaptic transmission, either enhancement or inhibition.</p>\n<p>Other advantages of SNNAP include:</p>\n<ul>\n<li>Written in JAVA and can run on virtually any type of computer system.</li>\n<li>Graphical user interface</li>\n<li>Ability to simulate common experimental manipulations.</li>\n<li>Modular organizations of input files.</li>\n</ul>",
+    "summary": "<p>Simulator for Neural Networks and Action Potentials (SNNAP) is a tool for rapid development and simulation of realistic models of single neurons and neural networks.\nIt includes mathematical descriptions of ion currents and intracellular second messengers and ions.\nIn addition, you can simulate current flow in multicompartment models of neurons by using the equations describing electric coupling.</p>\n<p>SNNAP also includes mathematical descriptions of intracellular second messengers and ions, and simulate the modulation of membrane currents and synaptic transmission, either enhancement or inhibition.\nOther advantages of SNNAP include:</p>\n<ul>\n<li>Written in JAVA and can run on virtually any type of computer system.</li>\n<li>Graphical user interface</li>\n<li>Ability to simulate common experimental manipulations.</li>\n<li>Modular organizations of input files.</li>\n</ul>",
     "urls": {
       "homepage": "https://med.uth.edu/nba/snnap/",
       "tutorial": "https://med.uth.edu/nba/snnap/snnap-tutorials/"
@@ -668,7 +667,7 @@
         "name": "NeuroML"
       }
     ],
-    "summary": "<p>The SONATA Data Format is a Scalable Open Data Format for multiscale neuronal network models and simulation output, jointly developed by the Allen Institute for Brain Science (AIBS) and the Blue Brain Project (BBP) of the \u00c9cole polytechnique f\u00e9d\u00e9rale de Lausanne (EPFL). The SONATA Data Format provides:\n- Facilities for representing nodes (cells) and edges (synapses/junctions) of a network. It uses table-based data structures, hdf5 and csv, to represent nodes, edges and their respective properties. Furthermore indexing procedures are specified to enable fast, parallelizable, and efficient partial lookup of individual nodes and edges. The use of hdf5 provides efficiency both in file size and IO time. , The format includes specific properties and naming conventions, but also allows modelers to extend node and edge model properties as they desire, to ensure models can be used with a variety of simulation frameworks and use cases. - A JSON-based file format for configuring simulations, including specifying variables to record from, and stimuli to apply. - A systematic schema for describing simulation output/reports making it easy for users to exchange their simulation output data, and moreover the underlying hdf5 based format permits efficient storage of variables such as spike times, membrane potential, and Ca2+ concentration.</p>",
+    "summary": "<p>The SONATA Data Format is a Scalable Open Data Format for multiscale neuronal network models and simulation output, jointly developed by the Allen Institute for Brain Science (AIBS) and the Blue Brain Project (BBP) of the \u00c9cole polytechnique f\u00e9d\u00e9rale de Lausanne (EPFL).</p>\n<p>The SONATA Data Format provides:</p>\n<ul>\n<li>Facilities for representing nodes (cells) and edges (synapses/junctions) of a network. It uses table-based data structures, hdf5 and csv, to represent nodes, edges and their respective properties. Furthermore indexing procedures are specified to enable fast, parallelizable, and efficient partial lookup of individual nodes and edges. The use of hdf5 provides efficiency both in file size and IO time. , The format includes specific properties and naming conventions, but also allows modelers to extend node and edge model properties as they desire, to ensure models can be used with a variety of simulation frameworks and use cases.</li>\n<li>A JSON-based file format for configuring simulations, including specifying variables to record from, and stimuli to apply.</li>\n<li>A systematic schema for describing simulation output/reports making it easy for users to exchange their simulation output data, and moreover the underlying hdf5 based format permits efficient storage of variables such as spike times, membrane potential, and Ca2+ concentration.</li>\n</ul>",
     "urls": {
       "homepage": "https://github.com/BlueBrain/sonata",
       "source": "https://github.com/BlueBrain/sonata"
@@ -681,7 +680,7 @@
     "name": "Steps",
     "operating_system": "Linux, MacOS, Windows",
     "processing_support": "Single Machine, GPU",
-    "summary": "<p>STEPS is a package for exact stochastic simulation of reaction-diffusion systems in arbitrarily complex 3D geometries. Our core simulation algorithm is an implementation of Gillespie's SSA, extended to deal with diffusion of molecules over the elements of a 3D tetrahedral mesh.</p>\n<p>While it was mainly developed for simulating detailed models of neuronal signaling pathways in dendrites and around synapses, it is a general tool and can be used for studying any biochemical pathway in which spatial gradients and morphology are thought to play a role.</p>\n<p>STEPS also supports accurate and efficient computational of local membrane potentials on tetrahedral meshes, with the addition of voltage-gated channels and currents. Tight integration between the reaction-diffusion calculations and the tetrahedral mesh potentials allows detailed coupling between molecular activity and local electrical excitability.</p>\n<p>We have implemented STEPS as a set of Python modules, which means STEPS users can use Python scripts to control all aspects of setting up the model, generating a mesh, controlling the simulation and generating and analyzing output. The core computational routines are still implemented as C/C++ extension modules for maximal speed of execution.</p>",
+    "summary": "<p>STEPS is a package for exact stochastic simulation of reaction-diffusion systems in arbitrarily complex 3D geometries.\nOur core simulation algorithm is an implementation of Gillespie's SSA, extended to deal with diffusion of molecules over the elements of a 3D tetrahedral mesh.</p>\n<p>While it was mainly developed for simulating detailed models of neuronal signaling pathways in dendrites and around synapses, it is a general tool and can be used for studying any biochemical pathway in which spatial gradients and morphology are thought to play a role.</p>\n<p>STEPS also supports accurate and efficient computational of local membrane potentials on tetrahedral meshes, with the addition of voltage-gated channels and currents.\nTight integration between the reaction-diffusion calculations and the tetrahedral mesh potentials allows detailed coupling between molecular activity and local electrical excitability.</p>\n<p>We have implemented STEPS as a set of Python modules, which means STEPS users can use Python scripts to control all aspects of setting up the model, generating a mesh, controlling the simulation and generating and analyzing output.\nThe core computational routines are still implemented as C/C++ extension modules for maximal speed of execution.</p>",
     "urls": {
       "documentation": "https://steps.sourceforge.net/manual/",
       "homepage": "https://steps.sourceforge.net/STEPS/default.php",
@@ -695,7 +694,7 @@
     "name": "TheVirtualBrain (TVB)",
     "operating_system": "Linux, MacOS, Windows",
     "processing_support": "Single Machine, Cluster, Supercomputer",
-    "summary": "<p>Simulating the human brain is the holy grail of neuroscience - offering a pioneering tool for understanding how our brain works and how to deal with its disorders like stroke, epilepsy or neurodegenerative diseases like Alzheimer's or Parkinson's.</p>\n<p>While large-scale research initiatives simulate neurons and small brain regions at the cellular level on massively parallel hardware, they are still years away from clinical applications.</p>\n<p>The Virtual Brain (TVB) takes a different approach and reduces complexity on the micro level to attain the macro organization. A TVB model of a patient's brain generates sufficiently accurate EEG, MEG, BOLD and SEEG signals by reducing the complexity millionfold through methods from statistical physics. The key is TVB\u2019s hybrid approach of merging individual anatomy from brain imaging data with state-of-the-art mathematical modeling.</p>",
+    "summary": "<p>Simulating the human brain is the holy grail of neuroscience - offering a pioneering tool for understanding how our brain works and how to deal with its disorders like stroke, epilepsy or neurodegenerative diseases like Alzheimer's or Parkinson's.</p>\n<p>While large-scale research initiatives simulate neurons and small brain regions at the cellular level on massively parallel hardware, they are still years away from clinical applications.</p>\n<p>The Virtual Brain (TVB) takes a different approach and reduces complexity on the micro level to attain the macro organization. A TVB model of a patient's brain generates sufficiently accurate EEG, MEG, BOLD and SEEG signals by reducing the complexity millionfold through methods from statistical physics.\nThe key is TVB\u2019s hybrid approach of merging individual anatomy from brain imaging data with state-of-the-art mathematical modeling.</p>",
     "urls": {
       "documentation": "http://docs.thevirtualbrain.org/",
       "download": "https://www.thevirtualbrain.org/tvb/zwei/brainsimulator-software",
@@ -717,7 +716,7 @@
         "name": "NeuroML"
       }
     ],
-    "summary": "<p>c302 is a framework for generating network models in NeuroML 2 based on C. elegans connectivity data. It is primarily intended as a way to generate neuronal networks at multiple levels of detail for the <a href=\"http://www.openworm.org/\">OpenWorm</a> project.</p>",
+    "summary": "<p>c302 is a framework for generating network models in NeuroML 2 based on C. elegans connectivity data.\nIt is primarily intended as a way to generate neuronal networks at multiple levels of detail for the <a href=\"http://www.openworm.org/\">OpenWorm</a> project.</p>",
     "urls": {
       "homepage": "https://www.opensourcebrain.org/projects/c302",
       "source": "https://github.com/openworm/c302"

--- a/src/data.py
+++ b/src/data.py
@@ -38,11 +38,7 @@ def parse_file(filename):
         A dictionary with the content of the yaml file
     """
     with open(filename) as f:
-        content = yaml.safe_load(f)
-        content_dict = {}
-        for element in content:
-            key, value = list(element.items())[0]
-            content_dict[key] = value
+        content_dict = yaml.safe_load(f)
 
     # Normalize the standard fields
 

--- a/tests/validate_data.py
+++ b/tests/validate_data.py
@@ -14,71 +14,55 @@ from schema import Schema, SchemaError, Optional, Or, And
 import yaml
 
 
-def get_field(data, field):
-    for item in data:
-        if field in item:
-            return item[field]
-    return None
+class SimselectSchema(Schema):
+    def validate(self, data, _is_simselect_schema=True):
+        data = super().validate(data, _is_simselect_schema=False)
+        if _is_simselect_schema and not "simulator" in data["features"]:
+            if "biological_level" in data:
+                raise SchemaError("biological_level is only valid for simulators")
+        return data
 
 
-data_schema = Schema(
-    [
-        {
-            "name": str,
-        },
-        {
-            Optional("short_name"): str,
-        },
-        {
-            "features": And(
-                str,
-                lambda s: all(
-                    ss.strip()
-                    in ["frontend", "simulator", "standard", "tool", "library", "API"]
-                    for ss in s.split(",")
-                ),
-                error="features must be a comma-separated list of 'frontend', 'simulator', 'standard', 'tool', 'library', 'API'",
+data_schema = SimselectSchema(
+    {
+        "name": str,
+        Optional("short_name"): str,
+        "features": And(
+            str,
+            lambda s: all(
+                ss.strip()
+                in ["frontend", "simulator", "standard", "tool", "library", "API"]
+                for ss in s.split(",")
             ),
+            error="features must be a comma-separated list of 'frontend', 'simulator', 'standard', 'tool', 'library', 'API'",
+        ),
+        "operating_system": Or(str, None),
+        Optional("biological_level"): Or(str, None),
+        Optional("processing_support"): Or(str, None),
+        "interface_language": Or(str, None),
+        "summary": str,
+        Optional("model_description_language"): Or(str, None),
+        Optional("urls"): {
+            Or(
+                "homepage",
+                "documentation",
+                "installation",
+                "tutorial",
+                "examples",
+                "email",
+                "chat",
+                "forum",
+                "issue tracker",
+                "source",
+                "download",
+            ): (
+                lambda url: isinstance(url, str)
+                and url.startswith("http")
+                or "@" in url
+            )
         },
-        {"operating_system": Or(str, None)},
-        {
-            "biological_level": Or(str, None),
-        },
-        {
-            "processing_support": Or(str, None),
-        },
-        {
-            "interface_language": Or(str, None),
-        },
-        {
-            "summary": str,
-        },
-        {
-            Optional("model_description_language"): Or(str, None),
-        },
-        {
-            Optional("urls"): {
-                Or(
-                    "homepage",
-                    "documentation",
-                    "installation",
-                    "tutorial",
-                    "examples",
-                    "email",
-                    "chat",
-                    "forum",
-                    "issue tracker",
-                    "source",
-                    "download",
-                ): (
-                    lambda url: isinstance(url, str)
-                    and url.startswith("http")
-                    or "@" in url
-                )
-            }
-        },
-        {Optional("relations"): [{"name": str, "description": str}]},
-    ]
+        Optional("relations"): [{"name": str, "description": str}],
+    }
 )
 
 data_files = Path(Path(__file__).parent / ".." / "simtools")
@@ -99,7 +83,7 @@ for datafile in file_list:
             errors.append(datafile.name)
             print(f"!! {e}")
             print(f"!! {datafile} is invalid.")
-        expected_name = get_field(text, "short_name") or get_field(text, "name")
+        expected_name = text.get("short_name") or text.get("name")
         expected_name = expected_name.replace(" ", "-") + ".yaml"
         if datafile.name != expected_name:
             errors.append(datafile.name)

--- a/yaml2json.py
+++ b/yaml2json.py
@@ -1,3 +1,4 @@
+from textwrap import dedent
 import glob
 import os
 
@@ -11,10 +12,7 @@ if __name__ == "__main__":
         if os.path.basename(fname) == "simtools.yaml":
             continue
         with open(fname) as f:
-            tool_data = {
-                list(item.keys())[0]: list(item.values())[0]
-                for item in yaml.load(f, Loader=yaml.FullLoader)
-            }
+            tool_data = yaml.load(f, Loader=yaml.SafeLoader)
             if "short_name" in tool_data:
                 name = tool_data["short_name"]
                 del tool_data["short_name"]


### PR DESCRIPTION
As discussed during our last meeting, this PR simplifies the YAML files to no longer be a list dicts (with a single entry each), but a simple dict. I.e., instead of
```yaml
- name: Simulator
- features: simulator
```
they now use
```yaml
name: Simulator
features: simulator
```