### PR TITLE
Fix click position

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@
         <div class="container-fluid" style="height: 80vh; width: 100vw;">
             <div class="row" >
                 <!-- graph -->
-                <div class="col col-8" style="height: 80vh" id="cy"><br /></div>
+                <div class="col col-8" style="height: 80vh" id="cy"></div>
 
                 <!-- details pane -->
                 <div class="col col-4 d-flex flex-column justify-content-between" style="height: 80vh; overflow: scroll" id="details">


### PR DESCRIPTION
The spurious `<br>` inside the cytoscape div shifted the mouse click circle down, meaning that you needed to aim your clicks higher than expected to select the correct thing.